### PR TITLE
Remove jessie-backports repo to fix build, add unzip

### DIFF
--- a/php70/Dockerfile
+++ b/php70/Dockerfile
@@ -9,8 +9,7 @@ ENV APACHE_RUN_GROUP www-data
 ENV APACHE_REQUEST_WORKERS 150
 ENV PATH=/var/www/vendor/bin:$PATH
 
-RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list \
-  && apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
       # for bz2
       bzip2 libbz2-dev \
       # for ftp
@@ -33,8 +32,10 @@ RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/so
       jpegoptim \
       optipng \
       pngquant \
-    # We need git >= 2.11 - see https://github.com/cweagans/composer-patches/issues/174.
-    && apt-get -t jessie-backports install -y git \
+      # for git
+      git \
+      # for composer
+      unzip \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \

--- a/php70/Dockerfile.dev
+++ b/php70/Dockerfile.dev
@@ -9,8 +9,7 @@ ENV APACHE_RUN_GROUP www-data
 ENV APACHE_REQUEST_WORKERS 150
 ENV PATH=/var/www/vendor/bin:$PATH
 
-RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list \
-  && apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
       # for bz2
       bzip2 libbz2-dev \
       # for ftp
@@ -33,8 +32,10 @@ RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/so
       jpegoptim \
       optipng \
       pngquant \
-    # We need git >= 2.11 - see https://github.com/cweagans/composer-patches/issues/174.
-    && apt-get -t jessie-backports install -y git \
+      # for git
+      git \
+      # for composer
+      unzip \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \

--- a/php71/Dockerfile
+++ b/php71/Dockerfile
@@ -9,8 +9,7 @@ ENV APACHE_RUN_GROUP www-data
 ENV APACHE_REQUEST_WORKERS 150
 ENV PATH=/var/www/vendor/bin:$PATH
 
-RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list \
-  && apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
       # for bz2
       bzip2 libbz2-dev \
       # for ftp
@@ -33,8 +32,10 @@ RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/so
       jpegoptim \
       optipng \
       pngquant \
-    # We need git >= 2.11 - see https://github.com/cweagans/composer-patches/issues/174.
-    && apt-get -t jessie-backports install -y git \
+      # for git
+      git \
+      # for composer
+      unzip \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \

--- a/php71/Dockerfile.dev
+++ b/php71/Dockerfile.dev
@@ -9,8 +9,7 @@ ENV APACHE_RUN_GROUP www-data
 ENV APACHE_REQUEST_WORKERS 150
 ENV PATH=/var/www/vendor/bin:$PATH
 
-RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list \
-  && apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
       # for bz2
       bzip2 libbz2-dev \
       # for ftp
@@ -33,8 +32,10 @@ RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/so
       jpegoptim \
       optipng \
       pngquant \
-    # We need git >= 2.11 - see https://github.com/cweagans/composer-patches/issues/174.
-    && apt-get -t jessie-backports install -y git \
+      # for git
+      git \
+      # for composer
+      unzip \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \

--- a/php72/Dockerfile
+++ b/php72/Dockerfile
@@ -9,8 +9,7 @@ ENV APACHE_RUN_GROUP www-data
 ENV APACHE_REQUEST_WORKERS 150
 ENV PATH=/var/www/vendor/bin:$PATH
 
-RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list \
-  && apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
       # for bz2
       bzip2 libbz2-dev \
       # for ftp
@@ -31,8 +30,10 @@ RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/so
       jpegoptim \
       optipng \
       pngquant \
-    # We need git >= 2.11 - see https://github.com/cweagans/composer-patches/issues/174.
-    && apt-get -t jessie-backports install -y git \
+      # for git
+      git \
+      # for composer
+      unzip \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \

--- a/php72/Dockerfile.dev
+++ b/php72/Dockerfile.dev
@@ -9,8 +9,7 @@ ENV APACHE_RUN_GROUP www-data
 ENV APACHE_REQUEST_WORKERS 150
 ENV PATH=/var/www/vendor/bin:$PATH
 
-RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list \
-  && apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
       # for bz2
       bzip2 libbz2-dev \
       # for ftp
@@ -31,8 +30,10 @@ RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/so
       jpegoptim \
       optipng \
       pngquant \
-    # We need git >= 2.11 - see https://github.com/cweagans/composer-patches/issues/174.
-    && apt-get -t jessie-backports install -y git \
+      # for git
+      git \
+      # for composer
+      unzip \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \

--- a/php73/Dockerfile
+++ b/php73/Dockerfile
@@ -30,6 +30,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       jpegoptim \
       optipng \
       pngquant \
+      # php7.3 needs zlib1g-dev and libzip-dev for the zip extension
+      # https://github.com/docker-library/php/issues/61#issuecomment-468874705
+      zlib1g-dev \
+      libzip-dev \
       # for git
       git \
       # for composer

--- a/php73/Dockerfile
+++ b/php73/Dockerfile
@@ -9,8 +9,7 @@ ENV APACHE_RUN_GROUP www-data
 ENV APACHE_REQUEST_WORKERS 150
 ENV PATH=/var/www/vendor/bin:$PATH
 
-RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list \
-  && apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
       # for bz2
       bzip2 libbz2-dev \
       # for ftp
@@ -31,12 +30,10 @@ RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/so
       jpegoptim \
       optipng \
       pngquant \
-      # php7.3 needs zlib1g-dev and libzip-dev for the zip extension
-      # https://github.com/docker-library/php/issues/61#issuecomment-468874705
-      zlib1g-dev \
-      libzip-dev \
-    # We need git >= 2.11 - see https://github.com/cweagans/composer-patches/issues/174.
-    && apt-get -t jessie-backports install -y git \
+      # for git
+      git \
+      # for composer
+      unzip \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \

--- a/php73/Dockerfile.dev
+++ b/php73/Dockerfile.dev
@@ -30,6 +30,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       jpegoptim \
       optipng \
       pngquant \
+      # php7.3 needs zlib1g-dev and libzip-dev for the zip extension
+      # https://github.com/docker-library/php/issues/61#issuecomment-468874705
+      zlib1g-dev \
+      libzip-dev \
       # for git
       git \
       # for composer

--- a/php73/Dockerfile.dev
+++ b/php73/Dockerfile.dev
@@ -9,8 +9,7 @@ ENV APACHE_RUN_GROUP www-data
 ENV APACHE_REQUEST_WORKERS 150
 ENV PATH=/var/www/vendor/bin:$PATH
 
-RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list \
-  && apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
       # for bz2
       bzip2 libbz2-dev \
       # for ftp
@@ -31,12 +30,10 @@ RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/so
       jpegoptim \
       optipng \
       pngquant \
-      # php7.3 needs zlib1g-dev and libzip-dev for the zip extension
-      # https://github.com/docker-library/php/issues/61#issuecomment-468874705
-      zlib1g-dev \
-      libzip-dev \
-    # We need git >= 2.11 - see https://github.com/cweagans/composer-patches/issues/174.
-    && apt-get -t jessie-backports install -y git \
+      # for git
+      git \
+      # for composer
+      unzip \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \


### PR DESCRIPTION
This PR addresses a build failure due to the `jessie-backports` repo being moved to the archive (none of our images will build at the moment). It actually looks like the PHP image (`php/7.*-apache`) got switched to Stretch at some point, so the reason we were using the backports repo in the first place (to get `git` >= 2.11.0) is no longer a thing.

Along the way of the upgrade, I noticed that Composer is throwing warnings about `unzip` not being there.  It seemed like an easy add, so I went ahead and did it.  