### PR TITLE
Update to node 10

### DIFF
--- a/php70/Dockerfile
+++ b/php70/Dockerfile
@@ -9,8 +9,7 @@ ENV APACHE_RUN_GROUP www-data
 ENV APACHE_REQUEST_WORKERS 150
 ENV PATH=/var/www/vendor/bin:$PATH
 
-RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list \
-  && apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
       # for bz2
       bzip2 libbz2-dev \
       # for ftp
@@ -33,8 +32,10 @@ RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/so
       jpegoptim \
       optipng \
       pngquant \
-    # We need git >= 2.11 - see https://github.com/cweagans/composer-patches/issues/174.
-    && apt-get -t jessie-backports install -y git \
+      # for git
+      git \
+      # for composer
+      unzip \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \

--- a/php70/Dockerfile.dev
+++ b/php70/Dockerfile.dev
@@ -92,30 +92,9 @@ CMD ["apache2-foreground-enhanced"]
 # /common-php70
 
 # Install development tools.
-# We install nvm, but also add node to $PATH directly
-# so we can use it through /bin/sh.
-ENV NVM_DIR /usr/local/nvm
-ENV NODE_VERSION v6.11.0
-ENV NODE_PATH $NVM_DIR/versions/node/$NODE_VERSION/lib/node_modules
-ENV PATH $NVM_DIR/versions/node/$NODE_VERSION/bin:$PATH
-ENV PHANTOMJS_VERSION 2.1.1
-
 RUN pecl install xdebug \
   && docker-php-ext-enable xdebug \
   && echo "xdebug.default_enable=0\nxdebug.coverage_enable=0" > $PHP_INI_DIR/conf.d/xdebug.ini \
-  # Nodejs, installed globally via nvm for all bash users.
-  && curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | PROFILE=/etc/bash.bashrc bash \
-  && . $NVM_DIR/nvm.sh \
-  && nvm install $NODE_VERSION \
-  && npm install -g yarn \
-  # Install Gulp
-  && npm install -g gulp \
-  # Install PhantomJS
-  && apt-get update \
-  # Install fonts and libtdl (for mounted docker binary usage)
-  && apt-get install -y libfontconfig libltdl7 \
-  && curl -sL "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2" | tar jx \
-	&& mv phantomjs-${PHANTOMJS_VERSION}-linux-x86_64 /usr/local/bin/phantomjs \
 	# Install Blackfire Probe
 	&& version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
   && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
@@ -133,7 +112,19 @@ RUN pecl install xdebug \
   && composer --working-dir=/usr/share/terminus require pantheon-systems/terminus --prefer-dist \
   && rm -r /root/.composer/cache \
   # Clean up the leftovers
-	&& npm cache clean --force \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# NodeJS,
+RUN apt-get update \
+  && apt-get install -y apt-transport-https lsb-release gnupg > /dev/null 2>&1 \
+  && curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
+  && echo 'deb https://deb.nodesource.com/node_10.x stretch main' > /etc/apt/sources.list.d/nodesource.list \
+  && echo 'deb-src https://deb.nodesource.com/node_10.x stretch main' >> /etc/apt/sources.list.d/nodesource.list \
+  && apt-get update \
+  && apt-get install -y nodejs \
+  && npm install -g yarn gulp \
+  && npm cache clean --force \
+  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+  && npm cache clean --force
 
 COPY test-dev.sh /test.sh

--- a/php70/Dockerfile.dev
+++ b/php70/Dockerfile.dev
@@ -9,8 +9,7 @@ ENV APACHE_RUN_GROUP www-data
 ENV APACHE_REQUEST_WORKERS 150
 ENV PATH=/var/www/vendor/bin:$PATH
 
-RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list \
-  && apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
       # for bz2
       bzip2 libbz2-dev \
       # for ftp
@@ -33,8 +32,10 @@ RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/so
       jpegoptim \
       optipng \
       pngquant \
-    # We need git >= 2.11 - see https://github.com/cweagans/composer-patches/issues/174.
-    && apt-get -t jessie-backports install -y git \
+      # for git
+      git \
+      # for composer
+      unzip \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \

--- a/php71/Dockerfile
+++ b/php71/Dockerfile
@@ -9,8 +9,7 @@ ENV APACHE_RUN_GROUP www-data
 ENV APACHE_REQUEST_WORKERS 150
 ENV PATH=/var/www/vendor/bin:$PATH
 
-RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list \
-  && apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
       # for bz2
       bzip2 libbz2-dev \
       # for ftp
@@ -33,8 +32,10 @@ RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/so
       jpegoptim \
       optipng \
       pngquant \
-    # We need git >= 2.11 - see https://github.com/cweagans/composer-patches/issues/174.
-    && apt-get -t jessie-backports install -y git \
+      # for git
+      git \
+      # for composer
+      unzip \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \

--- a/php71/Dockerfile.dev
+++ b/php71/Dockerfile.dev
@@ -92,30 +92,9 @@ CMD ["apache2-foreground-enhanced"]
 # /common-php70
 
 # Install development tools.
-# We install nvm, but also add node to $PATH directly
-# so we can use it through /bin/sh.
-ENV NVM_DIR /usr/local/nvm
-ENV NODE_VERSION v6.11.0
-ENV NODE_PATH $NVM_DIR/versions/node/$NODE_VERSION/lib/node_modules
-ENV PATH $NVM_DIR/versions/node/$NODE_VERSION/bin:$PATH
-ENV PHANTOMJS_VERSION 2.1.1
-
 RUN pecl install xdebug \
   && docker-php-ext-enable xdebug \
   && echo "xdebug.default_enable=0\nxdebug.coverage_enable=0" > $PHP_INI_DIR/conf.d/xdebug.ini \
-  # Nodejs, installed globally via nvm for all bash users.
-  && curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | PROFILE=/etc/bash.bashrc bash \
-  && . $NVM_DIR/nvm.sh \
-  && nvm install $NODE_VERSION \
-  && npm install -g yarn \
-  # Install Gulp
-  && npm install -g gulp \
-  # Install PhantomJS
-  && apt-get update \
-  # Install fonts and libtdl (for mounted docker binary usage)
-  && apt-get install -y libfontconfig libltdl7 \
-  && curl -sL "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2" | tar jx \
-	&& mv phantomjs-${PHANTOMJS_VERSION}-linux-x86_64 /usr/local/bin/phantomjs \
 	# Install Blackfire Probe
 	&& version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
   && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
@@ -133,7 +112,19 @@ RUN pecl install xdebug \
   && composer --working-dir=/usr/share/terminus require pantheon-systems/terminus --prefer-dist \
   && rm -r /root/.composer/cache \
   # Clean up the leftovers
-	&& npm cache clean --force \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# NodeJS,
+RUN apt-get update \
+  && apt-get install -y apt-transport-https lsb-release gnupg > /dev/null 2>&1 \
+  && curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
+  && echo 'deb https://deb.nodesource.com/node_10.x stretch main' > /etc/apt/sources.list.d/nodesource.list \
+  && echo 'deb-src https://deb.nodesource.com/node_10.x stretch main' >> /etc/apt/sources.list.d/nodesource.list \
+  && apt-get update \
+  && apt-get install -y nodejs \
+  && npm install -g yarn gulp \
+  && npm cache clean --force \
+  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+  && npm cache clean --force
 
 COPY test-dev.sh /test.sh

--- a/php71/Dockerfile.dev
+++ b/php71/Dockerfile.dev
@@ -9,8 +9,7 @@ ENV APACHE_RUN_GROUP www-data
 ENV APACHE_REQUEST_WORKERS 150
 ENV PATH=/var/www/vendor/bin:$PATH
 
-RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list \
-  && apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
       # for bz2
       bzip2 libbz2-dev \
       # for ftp
@@ -33,8 +32,10 @@ RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/so
       jpegoptim \
       optipng \
       pngquant \
-    # We need git >= 2.11 - see https://github.com/cweagans/composer-patches/issues/174.
-    && apt-get -t jessie-backports install -y git \
+      # for git
+      git \
+      # for composer
+      unzip \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \

--- a/php72/Dockerfile
+++ b/php72/Dockerfile
@@ -9,8 +9,7 @@ ENV APACHE_RUN_GROUP www-data
 ENV APACHE_REQUEST_WORKERS 150
 ENV PATH=/var/www/vendor/bin:$PATH
 
-RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list \
-  && apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
       # for bz2
       bzip2 libbz2-dev \
       # for ftp
@@ -31,8 +30,10 @@ RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/so
       jpegoptim \
       optipng \
       pngquant \
-    # We need git >= 2.11 - see https://github.com/cweagans/composer-patches/issues/174.
-    && apt-get -t jessie-backports install -y git \
+      # for git
+      git \
+      # for composer
+      unzip \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \

--- a/php72/Dockerfile.dev
+++ b/php72/Dockerfile.dev
@@ -9,8 +9,7 @@ ENV APACHE_RUN_GROUP www-data
 ENV APACHE_REQUEST_WORKERS 150
 ENV PATH=/var/www/vendor/bin:$PATH
 
-RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list \
-  && apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
       # for bz2
       bzip2 libbz2-dev \
       # for ftp
@@ -31,8 +30,10 @@ RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/so
       jpegoptim \
       optipng \
       pngquant \
-    # We need git >= 2.11 - see https://github.com/cweagans/composer-patches/issues/174.
-    && apt-get -t jessie-backports install -y git \
+      # for git
+      git \
+      # for composer
+      unzip \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \

--- a/php72/Dockerfile.dev
+++ b/php72/Dockerfile.dev
@@ -89,30 +89,9 @@ CMD ["apache2-foreground-enhanced"]
 # /common-php70
 
 # Install development tools.
-# We install nvm, but also add node to $PATH directly
-# so we can use it through /bin/sh.
-ENV NVM_DIR /usr/local/nvm
-ENV NODE_VERSION v6.11.0
-ENV NODE_PATH $NVM_DIR/versions/node/$NODE_VERSION/lib/node_modules
-ENV PATH $NVM_DIR/versions/node/$NODE_VERSION/bin:$PATH
-ENV PHANTOMJS_VERSION 2.1.1
-
 RUN pecl install xdebug \
   && docker-php-ext-enable xdebug \
   && echo "xdebug.default_enable=0\nxdebug.coverage_enable=0" > $PHP_INI_DIR/conf.d/xdebug.ini \
-  # Nodejs, installed globally via nvm for all bash users.
-  && curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | PROFILE=/etc/bash.bashrc bash \
-  && . $NVM_DIR/nvm.sh \
-  && nvm install $NODE_VERSION \
-  && npm install -g yarn \
-  # Install Gulp
-  && npm install -g gulp \
-  # Install PhantomJS
-  && apt-get update \
-  # Install fonts and libtdl (for mounted docker binary usage)
-  && apt-get install -y libfontconfig libltdl7 \
-  && curl -sL "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2" | tar jx \
-	&& mv phantomjs-${PHANTOMJS_VERSION}-linux-x86_64 /usr/local/bin/phantomjs \
 	# Install Blackfire Probe
 	&& version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
   && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
@@ -130,7 +109,19 @@ RUN pecl install xdebug \
   && composer --working-dir=/usr/share/terminus require pantheon-systems/terminus --prefer-dist \
   && rm -r /root/.composer/cache \
   # Clean up the leftovers
-	&& npm cache clean --force \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# NodeJS,
+RUN apt-get update \
+  && apt-get install -y apt-transport-https lsb-release gnupg > /dev/null 2>&1 \
+  && curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
+  && echo 'deb https://deb.nodesource.com/node_10.x stretch main' > /etc/apt/sources.list.d/nodesource.list \
+  && echo 'deb-src https://deb.nodesource.com/node_10.x stretch main' >> /etc/apt/sources.list.d/nodesource.list \
+  && apt-get update \
+  && apt-get install -y nodejs \
+  && npm install -g yarn gulp \
+  && npm cache clean --force \
+  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+  && npm cache clean --force
 
 COPY test-dev.sh /test.sh

--- a/php73/Dockerfile
+++ b/php73/Dockerfile
@@ -30,6 +30,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       jpegoptim \
       optipng \
       pngquant \
+      # php7.3 needs zlib1g-dev and libzip-dev for the zip extension
+      # https://github.com/docker-library/php/issues/61#issuecomment-468874705
+      zlib1g-dev \
+      libzip-dev \
       # for git
       git \
       # for composer

--- a/php73/Dockerfile
+++ b/php73/Dockerfile
@@ -9,8 +9,7 @@ ENV APACHE_RUN_GROUP www-data
 ENV APACHE_REQUEST_WORKERS 150
 ENV PATH=/var/www/vendor/bin:$PATH
 
-RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list \
-  && apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
       # for bz2
       bzip2 libbz2-dev \
       # for ftp
@@ -31,12 +30,10 @@ RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/so
       jpegoptim \
       optipng \
       pngquant \
-      # php7.3 needs zlib1g-dev and libzip-dev for the zip extension
-      # https://github.com/docker-library/php/issues/61#issuecomment-468874705
-      zlib1g-dev \
-      libzip-dev \
-    # We need git >= 2.11 - see https://github.com/cweagans/composer-patches/issues/174.
-    && apt-get -t jessie-backports install -y git \
+      # for git
+      git \
+      # for composer
+      unzip \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \

--- a/php73/Dockerfile.dev
+++ b/php73/Dockerfile.dev
@@ -93,30 +93,9 @@ CMD ["apache2-foreground-enhanced"]
 # /common-php70
 
 # Install development tools.
-# We install nvm, but also add node to $PATH directly
-# so we can use it through /bin/sh.
-ENV NVM_DIR /usr/local/nvm
-ENV NODE_VERSION v6.11.0
-ENV NODE_PATH $NVM_DIR/versions/node/$NODE_VERSION/lib/node_modules
-ENV PATH $NVM_DIR/versions/node/$NODE_VERSION/bin:$PATH
-ENV PHANTOMJS_VERSION 2.1.1
-
 RUN pecl install xdebug \
   && docker-php-ext-enable xdebug \
   && echo "xdebug.default_enable=0\nxdebug.coverage_enable=0" > $PHP_INI_DIR/conf.d/xdebug.ini \
-  # Nodejs, installed globally via nvm for all bash users.
-  && curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | PROFILE=/etc/bash.bashrc bash \
-  && . $NVM_DIR/nvm.sh \
-  && nvm install $NODE_VERSION \
-  && npm install -g yarn \
-  # Install Gulp
-  && npm install -g gulp \
-  # Install PhantomJS
-  && apt-get update \
-  # Install fonts and libtdl (for mounted docker binary usage)
-  && apt-get install -y libfontconfig libltdl7 \
-  && curl -sL "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2" | tar jx \
-	&& mv phantomjs-${PHANTOMJS_VERSION}-linux-x86_64 /usr/local/bin/phantomjs \
 	# Install Blackfire Probe
 	&& version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
   && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
@@ -134,7 +113,19 @@ RUN pecl install xdebug \
   && composer --working-dir=/usr/share/terminus require pantheon-systems/terminus --prefer-dist \
   && rm -r /root/.composer/cache \
   # Clean up the leftovers
-	&& npm cache clean --force \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# NodeJS,
+RUN apt-get update \
+  && apt-get install -y apt-transport-https lsb-release gnupg > /dev/null 2>&1 \
+  && curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
+  && echo 'deb https://deb.nodesource.com/node_10.x stretch main' > /etc/apt/sources.list.d/nodesource.list \
+  && echo 'deb-src https://deb.nodesource.com/node_10.x stretch main' >> /etc/apt/sources.list.d/nodesource.list \
+  && apt-get update \
+  && apt-get install -y nodejs \
+  && npm install -g yarn gulp \
+  && npm cache clean --force \
+  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+  && npm cache clean --force
 
 COPY test-dev.sh /test.sh

--- a/php73/Dockerfile.dev
+++ b/php73/Dockerfile.dev
@@ -30,6 +30,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       jpegoptim \
       optipng \
       pngquant \
+      # php7.3 needs zlib1g-dev and libzip-dev for the zip extension
+      # https://github.com/docker-library/php/issues/61#issuecomment-468874705
+      zlib1g-dev \
+      libzip-dev \
       # for git
       git \
       # for composer

--- a/php73/Dockerfile.dev
+++ b/php73/Dockerfile.dev
@@ -9,8 +9,7 @@ ENV APACHE_RUN_GROUP www-data
 ENV APACHE_REQUEST_WORKERS 150
 ENV PATH=/var/www/vendor/bin:$PATH
 
-RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list \
-  && apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
       # for bz2
       bzip2 libbz2-dev \
       # for ftp
@@ -31,12 +30,10 @@ RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/so
       jpegoptim \
       optipng \
       pngquant \
-      # php7.3 needs zlib1g-dev and libzip-dev for the zip extension
-      # https://github.com/docker-library/php/issues/61#issuecomment-468874705
-      zlib1g-dev \
-      libzip-dev \
-    # We need git >= 2.11 - see https://github.com/cweagans/composer-patches/issues/174.
-    && apt-get -t jessie-backports install -y git \
+      # for git
+      git \
+      # for composer
+      unzip \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \


### PR DESCRIPTION
This PR updates the version of NodeJS we install in the `-dev` variants from Node 6 to Node 10.  This brings us up to speed with the latest Node LTS release, which is necessary for a lot of newer JS modules, such as Cypress.  We've been writing our JS tooling recently using arrow functions, async/await, etc (all standard in Node 8+, but not available in Node 6), so this is necessary to run most of our modern tools.

Also included in this PR is the removal of PhantomJS, which hasn't been part of the scaffold for a year or two now.  I don't think we have projects out in the wild that use Phantomas or Backstop prior to the Puppeteer conversion, so hopefully this won't affect anything.

In my testing, this is actually a pretty low-impact change (I haven't been able to find stuff that breaks yet, but I bet we will!).  This PR includes the work from #9, just because I couldn't get it to build successfully otherwise. 