### PR TITLE
#12 Add php memory limit to Dockerfiles

### DIFF
--- a/php54/Dockerfile
+++ b/php54/Dockerfile
@@ -8,6 +8,7 @@ ENV APACHE_RUN_USER www-data
 ENV APACHE_RUN_GROUP www-data
 ENV APACHE_REQUEST_WORKERS 150
 ENV PATH=/var/www/vendor/bin:$PATH
+ENV COMPOSER_MEMORY_LIMIT "-1"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       # for bz2
@@ -63,8 +64,7 @@ RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-di
     && pecl install redis-2.2.8 apcu-4.0.11 \
     && docker-php-ext-enable redis apcu \
     # Set a reasonable max upload size
-    && printf "upload_max_filesize = 128M\npost_max_size = 128M" > $PHP_INI_DIR/conf.d/00-max_filesize.ini \
-    && echo "memory_limit=-1" > $PHP_INI_DIR/conf.d/00-memory-limit.ini
+    && printf "upload_max_filesize = 128M\npost_max_size = 128M" > $PHP_INI_DIR/conf.d/00-max_filesize.ini
 
 # Configure Apache:
 RUN a2enmod rewrite headers expires \

--- a/php54/Dockerfile
+++ b/php54/Dockerfile
@@ -63,7 +63,8 @@ RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-di
     && pecl install redis-2.2.8 apcu-4.0.11 \
     && docker-php-ext-enable redis apcu \
     # Set a reasonable max upload size
-    && printf "upload_max_filesize = 128M\npost_max_size = 128M" > $PHP_INI_DIR/conf.d/00-max_filesize.ini
+    && printf "upload_max_filesize = 128M\npost_max_size = 128M" > $PHP_INI_DIR/conf.d/00-max_filesize.ini \
+    && echo "memory_limit=-1" > $PHP_INI_DIR/conf.d/00-memory-limit.ini
 
 # Configure Apache:
 RUN a2enmod rewrite headers expires \

--- a/php55/Dockerfile
+++ b/php55/Dockerfile
@@ -8,6 +8,7 @@ ENV APACHE_RUN_USER www-data
 ENV APACHE_RUN_GROUP www-data
 ENV APACHE_REQUEST_WORKERS 150
 ENV PATH=/var/www/vendor/bin:$PATH
+ENV COMPOSER_MEMORY_LIMIT "-1"
 
 RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list \
   && apt-get update && apt-get install -y --no-install-recommends \
@@ -65,8 +66,7 @@ RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-di
     && pecl install redis-2.2.8 apcu-4.0.11 \
     && docker-php-ext-enable redis apcu \
     # Set a reasonable max upload size
-    && printf "upload_max_filesize = 128M\npost_max_size = 128M" > $PHP_INI_DIR/conf.d/00-max_filesize.ini \
-    && echo "memory_limit=-1" > $PHP_INI_DIR/conf.d/00-memory-limit.ini
+    && printf "upload_max_filesize = 128M\npost_max_size = 128M" > $PHP_INI_DIR/conf.d/00-max_filesize.ini
 
 # Configure Apache:
 RUN a2enmod rewrite headers expires \

--- a/php55/Dockerfile
+++ b/php55/Dockerfile
@@ -65,7 +65,8 @@ RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-di
     && pecl install redis-2.2.8 apcu-4.0.11 \
     && docker-php-ext-enable redis apcu \
     # Set a reasonable max upload size
-    && printf "upload_max_filesize = 128M\npost_max_size = 128M" > $PHP_INI_DIR/conf.d/00-max_filesize.ini
+    && printf "upload_max_filesize = 128M\npost_max_size = 128M" > $PHP_INI_DIR/conf.d/00-max_filesize.ini \
+    && echo "memory_limit=-1" > $PHP_INI_DIR/conf.d/00-memory-limit.ini
 
 # Configure Apache:
 RUN a2enmod rewrite headers expires \

--- a/php56/Dockerfile
+++ b/php56/Dockerfile
@@ -65,7 +65,8 @@ RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-di
     && pecl install redis-2.2.8 apcu-4.0.11 \
     && docker-php-ext-enable redis apcu \
     # Set a reasonable max upload size
-    && printf "upload_max_filesize = 128M\npost_max_size = 128M" > $PHP_INI_DIR/conf.d/00-max_filesize.ini
+    && printf "upload_max_filesize = 128M\npost_max_size = 128M" > $PHP_INI_DIR/conf.d/00-max_filesize.ini \
+    && echo "memory_limit=-1" > $PHP_INI_DIR/conf.d/00-memory-limit.ini
 
 # Configure Apache:
 RUN a2enmod rewrite headers expires \

--- a/php56/Dockerfile
+++ b/php56/Dockerfile
@@ -8,6 +8,7 @@ ENV APACHE_RUN_USER www-data
 ENV APACHE_RUN_GROUP www-data
 ENV APACHE_REQUEST_WORKERS 150
 ENV PATH=/var/www/vendor/bin:$PATH
+ENV COMPOSER_MEMORY_LIMIT "-1"
 
 RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main" >> /etc/apt/sources.list \
   && apt-get update && apt-get install -y --no-install-recommends \
@@ -65,8 +66,7 @@ RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-di
     && pecl install redis-2.2.8 apcu-4.0.11 \
     && docker-php-ext-enable redis apcu \
     # Set a reasonable max upload size
-    && printf "upload_max_filesize = 128M\npost_max_size = 128M" > $PHP_INI_DIR/conf.d/00-max_filesize.ini \
-    && echo "memory_limit=-1" > $PHP_INI_DIR/conf.d/00-memory-limit.ini
+    && printf "upload_max_filesize = 128M\npost_max_size = 128M" > $PHP_INI_DIR/conf.d/00-max_filesize.ini
 
 # Configure Apache:
 RUN a2enmod rewrite headers expires \

--- a/php70/Dockerfile
+++ b/php70/Dockerfile
@@ -65,7 +65,8 @@ RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-di
     && pecl install redis apcu \
     && docker-php-ext-enable redis apcu \
     # Set a reasonable max upload size
-    && printf "upload_max_filesize = 128M\npost_max_size = 128M" > $PHP_INI_DIR/conf.d/00-max_filesize.ini
+    && printf "upload_max_filesize = 128M\npost_max_size = 128M" > $PHP_INI_DIR/conf.d/00-max_filesize.ini \
+    && echo "memory_limit=-1" > $PHP_INI_DIR/conf.d/00-memory-limit.ini
 
 # Configure Apache:
 RUN a2enmod rewrite headers expires \

--- a/php70/Dockerfile
+++ b/php70/Dockerfile
@@ -8,6 +8,7 @@ ENV APACHE_RUN_USER www-data
 ENV APACHE_RUN_GROUP www-data
 ENV APACHE_REQUEST_WORKERS 150
 ENV PATH=/var/www/vendor/bin:$PATH
+ENV COMPOSER_MEMORY_LIMIT "-1"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       # for bz2
@@ -65,8 +66,7 @@ RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-di
     && pecl install redis apcu \
     && docker-php-ext-enable redis apcu \
     # Set a reasonable max upload size
-    && printf "upload_max_filesize = 128M\npost_max_size = 128M" > $PHP_INI_DIR/conf.d/00-max_filesize.ini \
-    && echo "memory_limit=-1" > $PHP_INI_DIR/conf.d/00-memory-limit.ini
+    && printf "upload_max_filesize = 128M\npost_max_size = 128M" > $PHP_INI_DIR/conf.d/00-max_filesize.ini
 
 # Configure Apache:
 RUN a2enmod rewrite headers expires \

--- a/php71/Dockerfile
+++ b/php71/Dockerfile
@@ -65,7 +65,8 @@ RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-di
     && pecl install redis apcu \
     && docker-php-ext-enable redis apcu \
     # Set a reasonable max upload size
-    && printf "upload_max_filesize = 128M\npost_max_size = 128M" > $PHP_INI_DIR/conf.d/00-max_filesize.ini
+    && printf "upload_max_filesize = 128M\npost_max_size = 128M" > $PHP_INI_DIR/conf.d/00-max_filesize.ini \
+    && echo "memory_limit=-1" > $PHP_INI_DIR/conf.d/00-memory-limit.ini
 
 # Configure Apache:
 RUN a2enmod rewrite headers expires \

--- a/php71/Dockerfile
+++ b/php71/Dockerfile
@@ -8,6 +8,7 @@ ENV APACHE_RUN_USER www-data
 ENV APACHE_RUN_GROUP www-data
 ENV APACHE_REQUEST_WORKERS 150
 ENV PATH=/var/www/vendor/bin:$PATH
+ENV COMPOSER_MEMORY_LIMIT "-1"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       # for bz2
@@ -65,8 +66,7 @@ RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-di
     && pecl install redis apcu \
     && docker-php-ext-enable redis apcu \
     # Set a reasonable max upload size
-    && printf "upload_max_filesize = 128M\npost_max_size = 128M" > $PHP_INI_DIR/conf.d/00-max_filesize.ini \
-    && echo "memory_limit=-1" > $PHP_INI_DIR/conf.d/00-memory-limit.ini
+    && printf "upload_max_filesize = 128M\npost_max_size = 128M" > $PHP_INI_DIR/conf.d/00-max_filesize.ini
 
 # Configure Apache:
 RUN a2enmod rewrite headers expires \

--- a/php72/Dockerfile
+++ b/php72/Dockerfile
@@ -8,6 +8,7 @@ ENV APACHE_RUN_USER www-data
 ENV APACHE_RUN_GROUP www-data
 ENV APACHE_REQUEST_WORKERS 150
 ENV PATH=/var/www/vendor/bin:$PATH
+ENV COMPOSER_MEMORY_LIMIT "-1"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       # for bz2
@@ -62,8 +63,7 @@ RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-di
     && pecl install redis apcu \
     && docker-php-ext-enable redis apcu \
     # Set a reasonable max upload size
-    && printf "upload_max_filesize = 128M\npost_max_size = 128M" > $PHP_INI_DIR/conf.d/00-max_filesize.ini \
-    && echo "memory_limit=-1" > $PHP_INI_DIR/conf.d/00-memory-limit.ini
+    && printf "upload_max_filesize = 128M\npost_max_size = 128M" > $PHP_INI_DIR/conf.d/00-max_filesize.ini
 
 # Configure Apache:
 RUN a2enmod rewrite headers expires \

--- a/php72/Dockerfile
+++ b/php72/Dockerfile
@@ -62,7 +62,8 @@ RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-di
     && pecl install redis apcu \
     && docker-php-ext-enable redis apcu \
     # Set a reasonable max upload size
-    && printf "upload_max_filesize = 128M\npost_max_size = 128M" > $PHP_INI_DIR/conf.d/00-max_filesize.ini
+    && printf "upload_max_filesize = 128M\npost_max_size = 128M" > $PHP_INI_DIR/conf.d/00-max_filesize.ini \
+    && echo "memory_limit=-1" > $PHP_INI_DIR/conf.d/00-memory-limit.ini
 
 # Configure Apache:
 RUN a2enmod rewrite headers expires \

--- a/php73/Dockerfile
+++ b/php73/Dockerfile
@@ -8,6 +8,7 @@ ENV APACHE_RUN_USER www-data
 ENV APACHE_RUN_GROUP www-data
 ENV APACHE_REQUEST_WORKERS 150
 ENV PATH=/var/www/vendor/bin:$PATH
+ENV COMPOSER_MEMORY_LIMIT "-1"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       # for bz2
@@ -66,8 +67,7 @@ RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-di
     && pecl install redis apcu \
     && docker-php-ext-enable redis apcu \
     # Set a reasonable max upload size
-    && printf "upload_max_filesize = 128M\npost_max_size = 128M" > $PHP_INI_DIR/conf.d/00-max_filesize.ini \
-    && echo "memory_limit=-1" > $PHP_INI_DIR/conf.d/00-memory-limit.ini
+    && printf "upload_max_filesize = 128M\npost_max_size = 128M" > $PHP_INI_DIR/conf.d/00-max_filesize.ini
 
 # Configure Apache:
 RUN a2enmod rewrite headers expires \

--- a/php73/Dockerfile
+++ b/php73/Dockerfile
@@ -66,7 +66,8 @@ RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-di
     && pecl install redis apcu \
     && docker-php-ext-enable redis apcu \
     # Set a reasonable max upload size
-    && printf "upload_max_filesize = 128M\npost_max_size = 128M" > $PHP_INI_DIR/conf.d/00-max_filesize.ini
+    && printf "upload_max_filesize = 128M\npost_max_size = 128M" > $PHP_INI_DIR/conf.d/00-max_filesize.ini \
+    && echo "memory_limit=-1" > $PHP_INI_DIR/conf.d/00-memory-limit.ini
 
 # Configure Apache:
 RUN a2enmod rewrite headers expires \


### PR DESCRIPTION
For issue #12 - Adds `echo "memory_limit=-1" > $PHP_INI_DIR/conf.d/00-memory-limit.ini` to Dockerfiles of all the Docker containers.