### PR TITLE
add php 7.4 boxes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,8 @@ jobs:
           - "7.2-dev"
           - "7.3"
           - "7.3-dev"
+          - "7.4"
+          - "7.4-dev"
     steps:
       - name: Checkout Code
         uses: actions/checkout@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
           - "7.2-dev"
           - "7.3"
           - "7.3-dev"
+          - "7.4"
+          - "7.4-dev"
     steps:
       - name: Checkout Code
         uses: actions/checkout@v1

--- a/7.0-dev/Dockerfile
+++ b/7.0-dev/Dockerfile
@@ -117,7 +117,7 @@ RUN apt-get update \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # XDebug
-RUN pecl install xdebug \
+RUN pecl install xdebug-2.9.0 \
   && docker-php-ext-enable xdebug \
   && echo "xdebug.default_enable=0\nxdebug.coverage_enable=0" > $PHP_INI_DIR/conf.d/xdebug.ini
 

--- a/7.4-dev/Dockerfile
+++ b/7.4-dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:{{ .Env.PHP_VERSION }}-apache
+FROM php:7.4-apache
 
 # common-php70
 ENV DEBIAN_FRONTEND noninteractive
@@ -37,7 +37,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       unzip \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN docker-php-ext-configure gd {{if (lt (atoi .Env.PHP_MINOR_VERSION) 4)}}--with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/{{ end }} \
+RUN docker-php-ext-configure gd  \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu \
     && docker-php-ext-install -j$(nproc) \
       bcmath \
@@ -101,7 +101,7 @@ ADD templates /templates
 ADD scripts/* /usr/local/bin/
 
 # /common-php70
-{{ if .Env.IS_DEV }}
+
 # NodeJS + Yarn
 ARG NODE_MAJOR_VERSION=10
 RUN apt-get update \
@@ -142,4 +142,4 @@ RUN curl -fsSOL https://github.com/pantheon-systems/terminus/releases/download/$
 
 # Gulp-cli.
 RUN npm i --no-cache -g gulp-cli
-{{ end }}
+

--- a/7.4-dev/scripts/check-apache-mem
+++ b/7.4-dev/scripts/check-apache-mem
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+ps -ylC apache2 | awk '{x += $8;y += 1} END {print "Apache Memory Usage (MB): "x/1024; print "Average Process Size (MB): "x/((y-1)*1024)}'

--- a/7.4-dev/scripts/docker-php-entrypoint
+++ b/7.4-dev/scripts/docker-php-entrypoint
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+
+# Write overrides to PHP and Apache. This is incompatible with starting the container
+# with any user other than root, but that's not advised for the PHP Apache container
+# anyway.
+dockerize \
+  -template /templates/php.overrides.tmpl:$PHP_INI_DIR/conf.d/99-runtime.ini \
+  -template /templates/mpm_prefork.conf.tmpl:/etc/apache2/mods-enabled/mpm_prefork.conf
+
+# Toggle XDebug completely on and off at runtime
+# Enable Xdebug by setting XDEBUG_ENABLE=1.
+if [ -z "$XDEBUG_ENABLE" ] || [ "$XDEBUG_ENABLE" -eq "0" ]; then
+  rm -f $PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini
+else
+  docker-php-ext-enable xdebug
+fi
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- apache2-foreground "$@"
+fi
+exec "$@"

--- a/7.4-dev/templates/mpm_prefork.conf.tmpl
+++ b/7.4-dev/templates/mpm_prefork.conf.tmpl
@@ -1,0 +1,8 @@
+# Allow overriding some settings to control performance.
+<IfModule mpm_prefork_module>
+	StartServers			 5
+	MinSpareServers		  5
+	MaxSpareServers		 10
+	MaxRequestWorkers	  {{ default .Env.APACHE_REQUEST_WORKERS "150" }}
+	MaxConnectionsPerChild   5000
+</IfModule>

--- a/7.4-dev/templates/php.overrides.tmpl
+++ b/7.4-dev/templates/php.overrides.tmpl
@@ -1,0 +1,17 @@
+; Set a reasonable max upload size
+upload_max_filesize = 128M
+post_max_size = 128M
+
+; These settings can be overridden at runtime by the presence of environment
+; variables.
+date.timezone={{ default .Env.TZ "UTC" }}
+{{ if .Env.PHP_MEMORY_LIMIT }}memory_limit={{ .Env.PHP_MEMORY_LIMIT }}{{ end }}
+{{ if .Env.SENDMAIL_PATH }}sendmail_path={{ .Env.SENDMAIL_PATH }}{{ end }}
+
+; XDebug can be conditionally triggered.
+{{ if .Env.XDEBUG_ENABLE }}
+xdebug.remote_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
+xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
+xdebug.remote_enable={{ default .Env.XDEBUG_REMOTE_ENABLE "On" }}
+xdebug.remote_autostart={{ default .Env.XDEBUG_REMOTE_AUTOSTART "On" }}
+{{ end }}

--- a/7.4-dev/test.yml
+++ b/7.4-dev/test.yml
@@ -1,0 +1,78 @@
+schemaVersion: "2.0.0"
+commandTests:
+  - name: "php should be configurable by environment variables"
+    setup: [["docker-php-entrypoint"]]
+    envVars:
+      - {key: PHP_MEMORY_LIMIT, value: 512M }
+      - {key: SENDMAIL_PATH, value: /bin/true }
+      - {key: TZ, value: America/New_York }
+    command: "php"
+    args: ["-i"]
+    expectedOutput:
+      - memory_limit => 512M => 512M
+      - sendmail_path => /bin/true => /bin/true
+      - date.timezone => America/New_York => America/New_York
+  - name: "php should use have default values"
+    setup: [["docker-php-entrypoint"]]
+    command: "php"
+    args: ["-i"]
+    expectedOutput:
+      - memory_limit => 128M => 128M
+      - sendmail_path =>  -t -i  =>  -t -i
+      - date.timezone => UTC => UTC
+  - name: "Composer should work"
+    command: composer
+    args: ["diagnose"]
+  - name: "Drush should be launchable"
+    command: drush
+    args: ["--drush-launcher-version"]
+    expectedOutput:
+      - "Drush Launcher Version: 0.6.0"
+
+  - name: "Blackfire agent should be present and configured"
+    command: "php"
+    args: ["-i"]
+    expectedOutput:
+      - Blackfire => enabled
+      - blackfire.agent_socket => tcp://blackfire:8707 => tcp://blackfire:8707
+  - name: "XDebug should be installed and disabled by default"
+    command: "php"
+    args: ["-m"]
+    setup: [["docker-php-entrypoint"]]
+    excludedOutput:
+      - Xdebug
+  - name: "XDebug should be enableable using a simple environment variable"
+    command: "php"
+    args: ["-m"]
+    setup: [["docker-php-entrypoint"]]
+    envVars:
+      - {key: XDEBUG_ENABLE, value: True }
+    expectedOutput:
+      - Xdebug
+  - name: "XDebug should be configurable by using environment variables"
+    command: "php"
+    args: ["-i"]
+    setup: [["docker-php-entrypoint"]]
+    envVars:
+      - {key: XDEBUG_ENABLE, value: True }
+      - {key: XDEBUG_REMOTE_HOST, value: foo.bar}
+      - {key: XDEBUG_IDEKEY, value: foobar}
+      - {key: XDEBUG_REMOTE_ENABLE, value: 1}
+      - {key: XDEBUG_REMOTE_AUTOSTART, value: 1}
+    expectedOutput:
+      - xdebug.remote_autostart => On => On
+      - xdebug.remote_enable => On => On
+      - xdebug.remote_host => foo.bar => foo.bar
+      - xdebug.idekey => foobar => foobar
+  - name: "NodeJS Should be installed and in the correct version"
+    command: "node"
+    args: ["--version"]
+    expectedOutput:
+      - v10.
+  - name: "Yarn should be installed and functional"
+    command: "yarn"
+    args: ["--version"]
+  - name: "Terminus should be installed and functional"
+    command: "terminus"
+    args: ["self:info"]
+

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:{{ .Env.PHP_VERSION }}-apache
+FROM php:7.4-apache
 
 # common-php70
 ENV DEBIAN_FRONTEND noninteractive
@@ -37,7 +37,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       unzip \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN docker-php-ext-configure gd {{if (lt (atoi .Env.PHP_MINOR_VERSION) 4)}}--with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/{{ end }} \
+RUN docker-php-ext-configure gd  \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu \
     && docker-php-ext-install -j$(nproc) \
       bcmath \
@@ -101,45 +101,4 @@ ADD templates /templates
 ADD scripts/* /usr/local/bin/
 
 # /common-php70
-{{ if .Env.IS_DEV }}
-# NodeJS + Yarn
-ARG NODE_MAJOR_VERSION=10
-RUN apt-get update \
-  && apt-get install -y apt-transport-https lsb-release gnupg > /dev/null 2>&1 \
-  && curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
-  && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-  && echo "deb https://deb.nodesource.com/node_$NODE_MAJOR_VERSION.x $(lsb_release --codename | cut -f2) main" > /etc/apt/sources.list.d/nodesource.list \
-  && echo "deb-src https://deb.nodesource.com/node_$NODE_MAJOR_VERSION.x $(lsb_release --codename | cut -f2) main" >> /etc/apt/sources.list.d/nodesource.list \
-  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
-  && apt-get update \
-  && apt-get install -y nodejs \
-  && apt-get install -y --no-install-recommends yarn \
-  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# XDebug
-RUN pecl install xdebug \
-  && docker-php-ext-enable xdebug \
-  && echo "xdebug.default_enable=0\nxdebug.coverage_enable=0" > $PHP_INI_DIR/conf.d/xdebug.ini
-
-# Blackfire Probe. Note: We do not install Blackfire CLI. You will
-# need that in order to trigger Blackfire tests. The probe just instruments
-# things on the server side.
-RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
-    && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
-    && mkdir -p /tmp/blackfire \
-    && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire \
-    && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
-    && printf "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8707\n" > $PHP_INI_DIR/conf.d/blackfire.ini \
-    && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
-
-# Terminus.
-ARG TERMINUS_VERSION=2.2.0
-ARG TERMINUS_SHA256="73fcdf6ceee23731c20bff45f668bde09230af347670a92e5ca97c2c008ae6e0"
-RUN curl -fsSOL https://github.com/pantheon-systems/terminus/releases/download/$TERMINUS_VERSION/terminus.phar \
-  && echo "$TERMINUS_SHA256 terminus.phar" | sha256sum -c - \
-  && mv terminus.phar /usr/local/bin/terminus \
-  && chmod +x /usr/local/bin/terminus
-
-# Gulp-cli.
-RUN npm i --no-cache -g gulp-cli
-{{ end }}

--- a/7.4/scripts/check-apache-mem
+++ b/7.4/scripts/check-apache-mem
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+ps -ylC apache2 | awk '{x += $8;y += 1} END {print "Apache Memory Usage (MB): "x/1024; print "Average Process Size (MB): "x/((y-1)*1024)}'

--- a/7.4/scripts/docker-php-entrypoint
+++ b/7.4/scripts/docker-php-entrypoint
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+
+# Write overrides to PHP and Apache. This is incompatible with starting the container
+# with any user other than root, but that's not advised for the PHP Apache container
+# anyway.
+dockerize \
+  -template /templates/php.overrides.tmpl:$PHP_INI_DIR/conf.d/99-runtime.ini \
+  -template /templates/mpm_prefork.conf.tmpl:/etc/apache2/mods-enabled/mpm_prefork.conf
+
+# Toggle XDebug completely on and off at runtime
+# Enable Xdebug by setting XDEBUG_ENABLE=1.
+if [ -z "$XDEBUG_ENABLE" ] || [ "$XDEBUG_ENABLE" -eq "0" ]; then
+  rm -f $PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini
+else
+  docker-php-ext-enable xdebug
+fi
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- apache2-foreground "$@"
+fi
+exec "$@"

--- a/7.4/templates/mpm_prefork.conf.tmpl
+++ b/7.4/templates/mpm_prefork.conf.tmpl
@@ -1,0 +1,8 @@
+# Allow overriding some settings to control performance.
+<IfModule mpm_prefork_module>
+	StartServers			 5
+	MinSpareServers		  5
+	MaxSpareServers		 10
+	MaxRequestWorkers	  {{ default .Env.APACHE_REQUEST_WORKERS "150" }}
+	MaxConnectionsPerChild   5000
+</IfModule>

--- a/7.4/templates/php.overrides.tmpl
+++ b/7.4/templates/php.overrides.tmpl
@@ -1,0 +1,17 @@
+; Set a reasonable max upload size
+upload_max_filesize = 128M
+post_max_size = 128M
+
+; These settings can be overridden at runtime by the presence of environment
+; variables.
+date.timezone={{ default .Env.TZ "UTC" }}
+{{ if .Env.PHP_MEMORY_LIMIT }}memory_limit={{ .Env.PHP_MEMORY_LIMIT }}{{ end }}
+{{ if .Env.SENDMAIL_PATH }}sendmail_path={{ .Env.SENDMAIL_PATH }}{{ end }}
+
+; XDebug can be conditionally triggered.
+{{ if .Env.XDEBUG_ENABLE }}
+xdebug.remote_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
+xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
+xdebug.remote_enable={{ default .Env.XDEBUG_REMOTE_ENABLE "On" }}
+xdebug.remote_autostart={{ default .Env.XDEBUG_REMOTE_AUTOSTART "On" }}
+{{ end }}

--- a/7.4/test.yml
+++ b/7.4/test.yml
@@ -1,0 +1,31 @@
+schemaVersion: "2.0.0"
+commandTests:
+  - name: "php should be configurable by environment variables"
+    setup: [["docker-php-entrypoint"]]
+    envVars:
+      - {key: PHP_MEMORY_LIMIT, value: 512M }
+      - {key: SENDMAIL_PATH, value: /bin/true }
+      - {key: TZ, value: America/New_York }
+    command: "php"
+    args: ["-i"]
+    expectedOutput:
+      - memory_limit => 512M => 512M
+      - sendmail_path => /bin/true => /bin/true
+      - date.timezone => America/New_York => America/New_York
+  - name: "php should use have default values"
+    setup: [["docker-php-entrypoint"]]
+    command: "php"
+    args: ["-i"]
+    expectedOutput:
+      - memory_limit => 128M => 128M
+      - sendmail_path =>  -t -i  =>  -t -i
+      - date.timezone => UTC => UTC
+  - name: "Composer should work"
+    command: composer
+    args: ["diagnose"]
+  - name: "Drush should be launchable"
+    command: drush
+    args: ["--drush-launcher-version"]
+    expectedOutput:
+      - "Drush Launcher Version: 0.6.0"
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,3 +24,9 @@ services:
   "7.3-dev":
     image: lastcallmedia/php:7.3-dev
     build: ./7.3-dev 
+  "7.4":
+    image: lastcallmedia/php:7.4
+    build: ./7.4
+  "7.4-dev":
+    image: lastcallmedia/php:7.4-dev
+    build: ./7.4-dev 

--- a/regenerate.sh
+++ b/regenerate.sh
@@ -12,15 +12,18 @@ set -e
 # ./regenerate.sh
 #
 #####
-php_versions=('7.0' '7.1' '7.2' '7.3')
+php_versions=('7.0' '7.1' '7.2' '7.3' '7.4')
 dc="version: '2'\nservices:\n"
 
 for PHP_VERSION in "${php_versions[@]}"; do
+  major=$(echo "$PHP_VERSION" | awk -F'.' '{ print $1 }')
+  minor=$(echo "$PHP_VERSION" | awk -F'.' '{ print $2 }')
+
   dir="./$PHP_VERSION"
   rm -rf $dir
   mkdir -p $dir
-  PHP_VERSION=$PHP_VERSION dockerize -template template/Dockerfile:$dir/Dockerfile
-  PHP_VERSION=$PHP_VERSION dockerize -template template/test.yml:$dir/test.yml
+  PHP_VERSION=$PHP_VERSION PHP_MAJOR_VERSION=$major PHP_MINOR_VERSION=$minor dockerize -template template/Dockerfile:$dir/Dockerfile
+  PHP_VERSION=$PHP_VERSION PHP_MAJOR_VERSION=$major PHP_MINOR_VERSION=$minor dockerize -template template/test.yml:$dir/test.yml
   cp -r template/scripts "$dir/scripts"
   cp -r template/templates "$dir/templates"
   dc+="  \"$PHP_VERSION\":\n    image: lastcallmedia/php:$PHP_VERSION\n    build: $dir\n"
@@ -28,8 +31,8 @@ for PHP_VERSION in "${php_versions[@]}"; do
   devDir="${dir}-dev"
   rm -rf $devDir
   mkdir -p $devDir
-  PHP_VERSION=$PHP_VERSION IS_DEV=true dockerize -template template/Dockerfile:$devDir/Dockerfile
-  PHP_VERSION=$PHP_VERSION IS_DEV=true dockerize -template template/test.yml:$devDir/test.yml
+  PHP_VERSION=$PHP_VERSION PHP_MAJOR_VERSION=$major PHP_MINOR_VERSION=$minor IS_DEV=true dockerize -template template/Dockerfile:$devDir/Dockerfile
+  PHP_VERSION=$PHP_VERSION PHP_MAJOR_VERSION=$major PHP_MINOR_VERSION=$minor IS_DEV=true dockerize -template template/test.yml:$devDir/test.yml
   cp -r template/scripts "$devDir/scripts"
   cp -r template/templates "$devDir/templates"
   dc+="  \"$PHP_VERSION-dev\":\n    image: lastcallmedia/php:$PHP_VERSION-dev\n    build: $devDir \n"

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -117,7 +117,6 @@ RUN apt-get update \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # XDebug
-# PHP 7.0 will only build on xdebug 2.9.0 or lower
 RUN pecl install xdebug{{if (eq (atoi .Env.PHP_MINOR_VERSION) 0)}}-2.9.0{{ end }} \
   && docker-php-ext-enable xdebug \
   && echo "xdebug.default_enable=0\nxdebug.coverage_enable=0" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -117,7 +117,8 @@ RUN apt-get update \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # XDebug
-RUN pecl install xdebug \
+# PHP 7.0 will only build on xdebug 2.9.0 or lower
+RUN pecl install xdebug{{if (eq (atoi .Env.PHP_MINOR_VERSION) 0)}}-2.9.0{{ end }} \
   && docker-php-ext-enable xdebug \
   && echo "xdebug.default_enable=0\nxdebug.coverage_enable=0" > $PHP_INI_DIR/conf.d/xdebug.ini
 


### PR DESCRIPTION
I added some php 7.4 boxes. Two of the `configure` options the lower versions are using (`--with-freetype-dir` and `--with-jpeg-dir`) cause an error with php 7.4's configure, so I added `PHP_MAJOR_VERSION` and `PHP_MINOR_VERSION` variables to the dockerize lines and a check to conditionally include these options in the template.