### PR TITLE
Add support for php8 images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,10 @@ jobs:
           - "7.3-dev"
           - "7.4"
           - "7.4-dev"
+          - "8.0"
+          - "8.0-dev"
+          - "8.1"
+          - "8.1-dev"
     steps:
       - name: Checkout Code
         uses: actions/checkout@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v1
       - name: Setup dockerize
-        uses: zcong1993/setup-dockerize@v1.1.0
+        uses: zcong1993/setup-dockerize@v1.2.2
         with:
           dockerize-version: '0.6.1'
       - name: Run regenerate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,10 @@ jobs:
           - "7.3-dev"
           - "7.4"
           - "7.4-dev"
+          - "8.0"
+          - "8.0-dev"
+          - "8.1"
+          - "8.1-dev"
     steps:
       - name: Checkout Code
         uses: actions/checkout@v1

--- a/7.0-dev/Dockerfile
+++ b/7.0-dev/Dockerfile
@@ -113,6 +113,8 @@ RUN apt-get update \
   && echo "deb-src https://deb.nodesource.com/node_$NODE_MAJOR_VERSION.x $(lsb_release --codename | cut -f2) main" >> /etc/apt/sources.list.d/nodesource.list \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
   && apt-get update \
+  # Force apt to use the deb.nodesource repository
+  && echo "Package: nodejs\nPin: origin deb.nodesource.com\nPin-priority: 1000" > /etc/apt/preferences.d/99-nodejs \
   && apt-get install -y nodejs \
   && apt-get install -y --no-install-recommends yarn \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/7.0-dev/Dockerfile
+++ b/7.0-dev/Dockerfile
@@ -120,6 +120,8 @@ RUN apt-get update \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # XDebug
+# TODO: Remove xdebug next time it causes problems. It is a lot of effort
+# to maintain, and no one is actually using it.
 RUN pecl install xdebug-2.9.0 \
   && docker-php-ext-enable xdebug \
   && echo "xdebug.default_enable=0\nxdebug.coverage_enable=0" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/7.0-dev/scripts/docker-php-entrypoint
+++ b/7.0-dev/scripts/docker-php-entrypoint
@@ -4,7 +4,9 @@ set -e
 # Write overrides to PHP and Apache. This is incompatible with starting the container
 # with any user other than root, but that's not advised for the PHP Apache container
 # anyway.
-dockerize \
+php_at_least_7_3=$(php -r 'echo version_compare(PHP_VERSION, "7.3") >= 0;')
+
+PHP_AT_LEAST_7_3=$php_at_least_7_3 dockerize \
   -template /templates/php.overrides.tmpl:$PHP_INI_DIR/conf.d/99-runtime.ini \
   -template /templates/mpm_prefork.conf.tmpl:/etc/apache2/mods-enabled/mpm_prefork.conf
 

--- a/7.0-dev/scripts/docker-php-entrypoint
+++ b/7.0-dev/scripts/docker-php-entrypoint
@@ -4,6 +4,9 @@ set -e
 # Write overrides to PHP and Apache. This is incompatible with starting the container
 # with any user other than root, but that's not advised for the PHP Apache container
 # anyway.
+
+# PHP 7.3 is the first version that uses Xdebug 3; it's easier to check
+# the php version in here than the Xdebug version
 php_at_least_7_3=$(php -r 'echo version_compare(PHP_VERSION, "7.3") >= 0;')
 
 PHP_AT_LEAST_7_3=$php_at_least_7_3 dockerize \

--- a/7.0-dev/templates/php.overrides.tmpl
+++ b/7.0-dev/templates/php.overrides.tmpl
@@ -10,8 +10,14 @@ date.timezone={{ default .Env.TZ "UTC" }}
 
 ; XDebug can be conditionally triggered.
 {{ if .Env.XDEBUG_ENABLE }}
+{{ if .Env.PHP_AT_LEAST_7_3 }}
+xdebug.client_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
+xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
+xdebug.start_with_request={{ default .Env.XDEBUG_START_WITH_REQUEST "yes" }}
+{{ else }}
 xdebug.remote_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
 xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
 xdebug.remote_enable={{ default .Env.XDEBUG_REMOTE_ENABLE "On" }}
 xdebug.remote_autostart={{ default .Env.XDEBUG_REMOTE_AUTOSTART "On" }}
+{{ end }}
 {{ end }}

--- a/7.0-dev/test.yml
+++ b/7.0-dev/test.yml
@@ -57,13 +57,17 @@ commandTests:
       - {key: XDEBUG_ENABLE, value: True }
       - {key: XDEBUG_REMOTE_HOST, value: foo.bar}
       - {key: XDEBUG_IDEKEY, value: foobar}
+
       - {key: XDEBUG_REMOTE_ENABLE, value: 1}
       - {key: XDEBUG_REMOTE_AUTOSTART, value: 1}
+
     expectedOutput:
+      - xdebug.idekey => foobar => foobar
+
       - xdebug.remote_autostart => On => On
       - xdebug.remote_enable => On => On
       - xdebug.remote_host => foo.bar => foo.bar
-      - xdebug.idekey => foobar => foobar
+
   - name: "NodeJS Should be installed and in the correct version"
     command: "node"
     args: ["--version"]

--- a/7.0-dev/test.yml
+++ b/7.0-dev/test.yml
@@ -18,7 +18,7 @@ commandTests:
     args: ["-i"]
     expectedOutput:
       - memory_limit => 128M => 128M
-      - sendmail_path =>  -t -i  =>  -t -i
+      - sendmail_path => (?:\/usr\/sbin\/sendmail)? -t -i\s*=> (?:\/usr\/sbin\/sendmail)? -t -i
       - date.timezone => UTC => UTC
   - name: "Composer should work"
     command: composer

--- a/7.0/scripts/docker-php-entrypoint
+++ b/7.0/scripts/docker-php-entrypoint
@@ -4,7 +4,9 @@ set -e
 # Write overrides to PHP and Apache. This is incompatible with starting the container
 # with any user other than root, but that's not advised for the PHP Apache container
 # anyway.
-dockerize \
+php_at_least_7_3=$(php -r 'echo version_compare(PHP_VERSION, "7.3") >= 0;')
+
+PHP_AT_LEAST_7_3=$php_at_least_7_3 dockerize \
   -template /templates/php.overrides.tmpl:$PHP_INI_DIR/conf.d/99-runtime.ini \
   -template /templates/mpm_prefork.conf.tmpl:/etc/apache2/mods-enabled/mpm_prefork.conf
 

--- a/7.0/scripts/docker-php-entrypoint
+++ b/7.0/scripts/docker-php-entrypoint
@@ -4,6 +4,9 @@ set -e
 # Write overrides to PHP and Apache. This is incompatible with starting the container
 # with any user other than root, but that's not advised for the PHP Apache container
 # anyway.
+
+# PHP 7.3 is the first version that uses Xdebug 3; it's easier to check
+# the php version in here than the Xdebug version
 php_at_least_7_3=$(php -r 'echo version_compare(PHP_VERSION, "7.3") >= 0;')
 
 PHP_AT_LEAST_7_3=$php_at_least_7_3 dockerize \

--- a/7.0/templates/php.overrides.tmpl
+++ b/7.0/templates/php.overrides.tmpl
@@ -10,8 +10,14 @@ date.timezone={{ default .Env.TZ "UTC" }}
 
 ; XDebug can be conditionally triggered.
 {{ if .Env.XDEBUG_ENABLE }}
+{{ if .Env.PHP_AT_LEAST_7_3 }}
+xdebug.client_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
+xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
+xdebug.start_with_request={{ default .Env.XDEBUG_START_WITH_REQUEST "yes" }}
+{{ else }}
 xdebug.remote_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
 xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
 xdebug.remote_enable={{ default .Env.XDEBUG_REMOTE_ENABLE "On" }}
 xdebug.remote_autostart={{ default .Env.XDEBUG_REMOTE_AUTOSTART "On" }}
+{{ end }}
 {{ end }}

--- a/7.0/test.yml
+++ b/7.0/test.yml
@@ -18,7 +18,7 @@ commandTests:
     args: ["-i"]
     expectedOutput:
       - memory_limit => 128M => 128M
-      - sendmail_path =>  -t -i  =>  -t -i
+      - sendmail_path => (?:\/usr\/sbin\/sendmail)? -t -i\s*=> (?:\/usr\/sbin\/sendmail)? -t -i
       - date.timezone => UTC => UTC
   - name: "Composer should work"
     command: composer

--- a/7.1-dev/Dockerfile
+++ b/7.1-dev/Dockerfile
@@ -113,6 +113,8 @@ RUN apt-get update \
   && echo "deb-src https://deb.nodesource.com/node_$NODE_MAJOR_VERSION.x $(lsb_release --codename | cut -f2) main" >> /etc/apt/sources.list.d/nodesource.list \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
   && apt-get update \
+  # Force apt to use the deb.nodesource repository
+  && echo "Package: nodejs\nPin: origin deb.nodesource.com\nPin-priority: 1000" > /etc/apt/preferences.d/99-nodejs \
   && apt-get install -y nodejs \
   && apt-get install -y --no-install-recommends yarn \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/7.1-dev/Dockerfile
+++ b/7.1-dev/Dockerfile
@@ -120,6 +120,8 @@ RUN apt-get update \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # XDebug
+# TODO: Remove xdebug next time it causes problems. It is a lot of effort
+# to maintain, and no one is actually using it.
 RUN pecl install xdebug-2.9.0 \
   && docker-php-ext-enable xdebug \
   && echo "xdebug.default_enable=0\nxdebug.coverage_enable=0" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/7.1-dev/scripts/docker-php-entrypoint
+++ b/7.1-dev/scripts/docker-php-entrypoint
@@ -4,7 +4,9 @@ set -e
 # Write overrides to PHP and Apache. This is incompatible with starting the container
 # with any user other than root, but that's not advised for the PHP Apache container
 # anyway.
-dockerize \
+php_at_least_7_3=$(php -r 'echo version_compare(PHP_VERSION, "7.3") >= 0;')
+
+PHP_AT_LEAST_7_3=$php_at_least_7_3 dockerize \
   -template /templates/php.overrides.tmpl:$PHP_INI_DIR/conf.d/99-runtime.ini \
   -template /templates/mpm_prefork.conf.tmpl:/etc/apache2/mods-enabled/mpm_prefork.conf
 

--- a/7.1-dev/scripts/docker-php-entrypoint
+++ b/7.1-dev/scripts/docker-php-entrypoint
@@ -4,6 +4,9 @@ set -e
 # Write overrides to PHP and Apache. This is incompatible with starting the container
 # with any user other than root, but that's not advised for the PHP Apache container
 # anyway.
+
+# PHP 7.3 is the first version that uses Xdebug 3; it's easier to check
+# the php version in here than the Xdebug version
 php_at_least_7_3=$(php -r 'echo version_compare(PHP_VERSION, "7.3") >= 0;')
 
 PHP_AT_LEAST_7_3=$php_at_least_7_3 dockerize \

--- a/7.1-dev/templates/php.overrides.tmpl
+++ b/7.1-dev/templates/php.overrides.tmpl
@@ -10,8 +10,14 @@ date.timezone={{ default .Env.TZ "UTC" }}
 
 ; XDebug can be conditionally triggered.
 {{ if .Env.XDEBUG_ENABLE }}
+{{ if .Env.PHP_AT_LEAST_7_3 }}
+xdebug.client_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
+xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
+xdebug.start_with_request={{ default .Env.XDEBUG_START_WITH_REQUEST "yes" }}
+{{ else }}
 xdebug.remote_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
 xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
 xdebug.remote_enable={{ default .Env.XDEBUG_REMOTE_ENABLE "On" }}
 xdebug.remote_autostart={{ default .Env.XDEBUG_REMOTE_AUTOSTART "On" }}
+{{ end }}
 {{ end }}

--- a/7.1-dev/test.yml
+++ b/7.1-dev/test.yml
@@ -57,13 +57,17 @@ commandTests:
       - {key: XDEBUG_ENABLE, value: True }
       - {key: XDEBUG_REMOTE_HOST, value: foo.bar}
       - {key: XDEBUG_IDEKEY, value: foobar}
+
       - {key: XDEBUG_REMOTE_ENABLE, value: 1}
       - {key: XDEBUG_REMOTE_AUTOSTART, value: 1}
+
     expectedOutput:
+      - xdebug.idekey => foobar => foobar
+
       - xdebug.remote_autostart => On => On
       - xdebug.remote_enable => On => On
       - xdebug.remote_host => foo.bar => foo.bar
-      - xdebug.idekey => foobar => foobar
+
   - name: "NodeJS Should be installed and in the correct version"
     command: "node"
     args: ["--version"]

--- a/7.1-dev/test.yml
+++ b/7.1-dev/test.yml
@@ -18,7 +18,7 @@ commandTests:
     args: ["-i"]
     expectedOutput:
       - memory_limit => 128M => 128M
-      - sendmail_path =>  -t -i  =>  -t -i
+      - sendmail_path => (?:\/usr\/sbin\/sendmail)? -t -i\s*=> (?:\/usr\/sbin\/sendmail)? -t -i
       - date.timezone => UTC => UTC
   - name: "Composer should work"
     command: composer

--- a/7.1/scripts/docker-php-entrypoint
+++ b/7.1/scripts/docker-php-entrypoint
@@ -4,7 +4,9 @@ set -e
 # Write overrides to PHP and Apache. This is incompatible with starting the container
 # with any user other than root, but that's not advised for the PHP Apache container
 # anyway.
-dockerize \
+php_at_least_7_3=$(php -r 'echo version_compare(PHP_VERSION, "7.3") >= 0;')
+
+PHP_AT_LEAST_7_3=$php_at_least_7_3 dockerize \
   -template /templates/php.overrides.tmpl:$PHP_INI_DIR/conf.d/99-runtime.ini \
   -template /templates/mpm_prefork.conf.tmpl:/etc/apache2/mods-enabled/mpm_prefork.conf
 

--- a/7.1/scripts/docker-php-entrypoint
+++ b/7.1/scripts/docker-php-entrypoint
@@ -4,6 +4,9 @@ set -e
 # Write overrides to PHP and Apache. This is incompatible with starting the container
 # with any user other than root, but that's not advised for the PHP Apache container
 # anyway.
+
+# PHP 7.3 is the first version that uses Xdebug 3; it's easier to check
+# the php version in here than the Xdebug version
 php_at_least_7_3=$(php -r 'echo version_compare(PHP_VERSION, "7.3") >= 0;')
 
 PHP_AT_LEAST_7_3=$php_at_least_7_3 dockerize \

--- a/7.1/templates/php.overrides.tmpl
+++ b/7.1/templates/php.overrides.tmpl
@@ -10,8 +10,14 @@ date.timezone={{ default .Env.TZ "UTC" }}
 
 ; XDebug can be conditionally triggered.
 {{ if .Env.XDEBUG_ENABLE }}
+{{ if .Env.PHP_AT_LEAST_7_3 }}
+xdebug.client_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
+xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
+xdebug.start_with_request={{ default .Env.XDEBUG_START_WITH_REQUEST "yes" }}
+{{ else }}
 xdebug.remote_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
 xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
 xdebug.remote_enable={{ default .Env.XDEBUG_REMOTE_ENABLE "On" }}
 xdebug.remote_autostart={{ default .Env.XDEBUG_REMOTE_AUTOSTART "On" }}
+{{ end }}
 {{ end }}

--- a/7.1/test.yml
+++ b/7.1/test.yml
@@ -18,7 +18,7 @@ commandTests:
     args: ["-i"]
     expectedOutput:
       - memory_limit => 128M => 128M
-      - sendmail_path =>  -t -i  =>  -t -i
+      - sendmail_path => (?:\/usr\/sbin\/sendmail)? -t -i\s*=> (?:\/usr\/sbin\/sendmail)? -t -i
       - date.timezone => UTC => UTC
   - name: "Composer should work"
     command: composer

--- a/7.2-dev/Dockerfile
+++ b/7.2-dev/Dockerfile
@@ -113,6 +113,8 @@ RUN apt-get update \
   && echo "deb-src https://deb.nodesource.com/node_$NODE_MAJOR_VERSION.x $(lsb_release --codename | cut -f2) main" >> /etc/apt/sources.list.d/nodesource.list \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
   && apt-get update \
+  # Force apt to use the deb.nodesource repository
+  && echo "Package: nodejs\nPin: origin deb.nodesource.com\nPin-priority: 1000" > /etc/apt/preferences.d/99-nodejs \
   && apt-get install -y nodejs \
   && apt-get install -y --no-install-recommends yarn \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/7.2-dev/Dockerfile
+++ b/7.2-dev/Dockerfile
@@ -120,6 +120,8 @@ RUN apt-get update \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # XDebug
+# TODO: Remove xdebug next time it causes problems. It is a lot of effort
+# to maintain, and no one is actually using it.
 RUN pecl install xdebug-2.9.0 \
   && docker-php-ext-enable xdebug \
   && echo "xdebug.default_enable=0\nxdebug.coverage_enable=0" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/7.2-dev/scripts/docker-php-entrypoint
+++ b/7.2-dev/scripts/docker-php-entrypoint
@@ -4,7 +4,9 @@ set -e
 # Write overrides to PHP and Apache. This is incompatible with starting the container
 # with any user other than root, but that's not advised for the PHP Apache container
 # anyway.
-dockerize \
+php_at_least_7_3=$(php -r 'echo version_compare(PHP_VERSION, "7.3") >= 0;')
+
+PHP_AT_LEAST_7_3=$php_at_least_7_3 dockerize \
   -template /templates/php.overrides.tmpl:$PHP_INI_DIR/conf.d/99-runtime.ini \
   -template /templates/mpm_prefork.conf.tmpl:/etc/apache2/mods-enabled/mpm_prefork.conf
 

--- a/7.2-dev/scripts/docker-php-entrypoint
+++ b/7.2-dev/scripts/docker-php-entrypoint
@@ -4,6 +4,9 @@ set -e
 # Write overrides to PHP and Apache. This is incompatible with starting the container
 # with any user other than root, but that's not advised for the PHP Apache container
 # anyway.
+
+# PHP 7.3 is the first version that uses Xdebug 3; it's easier to check
+# the php version in here than the Xdebug version
 php_at_least_7_3=$(php -r 'echo version_compare(PHP_VERSION, "7.3") >= 0;')
 
 PHP_AT_LEAST_7_3=$php_at_least_7_3 dockerize \

--- a/7.2-dev/templates/php.overrides.tmpl
+++ b/7.2-dev/templates/php.overrides.tmpl
@@ -10,8 +10,14 @@ date.timezone={{ default .Env.TZ "UTC" }}
 
 ; XDebug can be conditionally triggered.
 {{ if .Env.XDEBUG_ENABLE }}
+{{ if .Env.PHP_AT_LEAST_7_3 }}
+xdebug.client_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
+xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
+xdebug.start_with_request={{ default .Env.XDEBUG_START_WITH_REQUEST "yes" }}
+{{ else }}
 xdebug.remote_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
 xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
 xdebug.remote_enable={{ default .Env.XDEBUG_REMOTE_ENABLE "On" }}
 xdebug.remote_autostart={{ default .Env.XDEBUG_REMOTE_AUTOSTART "On" }}
+{{ end }}
 {{ end }}

--- a/7.2-dev/test.yml
+++ b/7.2-dev/test.yml
@@ -57,13 +57,17 @@ commandTests:
       - {key: XDEBUG_ENABLE, value: True }
       - {key: XDEBUG_REMOTE_HOST, value: foo.bar}
       - {key: XDEBUG_IDEKEY, value: foobar}
+
       - {key: XDEBUG_REMOTE_ENABLE, value: 1}
       - {key: XDEBUG_REMOTE_AUTOSTART, value: 1}
+
     expectedOutput:
+      - xdebug.idekey => foobar => foobar
+
       - xdebug.remote_autostart => On => On
       - xdebug.remote_enable => On => On
       - xdebug.remote_host => foo.bar => foo.bar
-      - xdebug.idekey => foobar => foobar
+
   - name: "NodeJS Should be installed and in the correct version"
     command: "node"
     args: ["--version"]

--- a/7.2-dev/test.yml
+++ b/7.2-dev/test.yml
@@ -18,7 +18,7 @@ commandTests:
     args: ["-i"]
     expectedOutput:
       - memory_limit => 128M => 128M
-      - sendmail_path =>  -t -i  =>  -t -i
+      - sendmail_path => (?:\/usr\/sbin\/sendmail)? -t -i\s*=> (?:\/usr\/sbin\/sendmail)? -t -i
       - date.timezone => UTC => UTC
   - name: "Composer should work"
     command: composer

--- a/7.2/scripts/docker-php-entrypoint
+++ b/7.2/scripts/docker-php-entrypoint
@@ -4,7 +4,9 @@ set -e
 # Write overrides to PHP and Apache. This is incompatible with starting the container
 # with any user other than root, but that's not advised for the PHP Apache container
 # anyway.
-dockerize \
+php_at_least_7_3=$(php -r 'echo version_compare(PHP_VERSION, "7.3") >= 0;')
+
+PHP_AT_LEAST_7_3=$php_at_least_7_3 dockerize \
   -template /templates/php.overrides.tmpl:$PHP_INI_DIR/conf.d/99-runtime.ini \
   -template /templates/mpm_prefork.conf.tmpl:/etc/apache2/mods-enabled/mpm_prefork.conf
 

--- a/7.2/scripts/docker-php-entrypoint
+++ b/7.2/scripts/docker-php-entrypoint
@@ -4,6 +4,9 @@ set -e
 # Write overrides to PHP and Apache. This is incompatible with starting the container
 # with any user other than root, but that's not advised for the PHP Apache container
 # anyway.
+
+# PHP 7.3 is the first version that uses Xdebug 3; it's easier to check
+# the php version in here than the Xdebug version
 php_at_least_7_3=$(php -r 'echo version_compare(PHP_VERSION, "7.3") >= 0;')
 
 PHP_AT_LEAST_7_3=$php_at_least_7_3 dockerize \

--- a/7.2/templates/php.overrides.tmpl
+++ b/7.2/templates/php.overrides.tmpl
@@ -10,8 +10,14 @@ date.timezone={{ default .Env.TZ "UTC" }}
 
 ; XDebug can be conditionally triggered.
 {{ if .Env.XDEBUG_ENABLE }}
+{{ if .Env.PHP_AT_LEAST_7_3 }}
+xdebug.client_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
+xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
+xdebug.start_with_request={{ default .Env.XDEBUG_START_WITH_REQUEST "yes" }}
+{{ else }}
 xdebug.remote_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
 xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
 xdebug.remote_enable={{ default .Env.XDEBUG_REMOTE_ENABLE "On" }}
 xdebug.remote_autostart={{ default .Env.XDEBUG_REMOTE_AUTOSTART "On" }}
+{{ end }}
 {{ end }}

--- a/7.2/test.yml
+++ b/7.2/test.yml
@@ -18,7 +18,7 @@ commandTests:
     args: ["-i"]
     expectedOutput:
       - memory_limit => 128M => 128M
-      - sendmail_path =>  -t -i  =>  -t -i
+      - sendmail_path => (?:\/usr\/sbin\/sendmail)? -t -i\s*=> (?:\/usr\/sbin\/sendmail)? -t -i
       - date.timezone => UTC => UTC
   - name: "Composer should work"
     command: composer

--- a/7.3-dev/Dockerfile
+++ b/7.3-dev/Dockerfile
@@ -120,7 +120,8 @@ RUN apt-get update \
 # XDebug
 RUN pecl install xdebug \
   && docker-php-ext-enable xdebug \
-  && echo "xdebug.default_enable=0\nxdebug.coverage_enable=0" > $PHP_INI_DIR/conf.d/xdebug.ini
+  && echo "xdebug.mode=debug" > $PHP_INI_DIR/conf.d/xdebug.ini
+
 
 # Blackfire Probe. Note: We do not install Blackfire CLI. You will
 # need that in order to trigger Blackfire tests. The probe just instruments

--- a/7.3-dev/Dockerfile
+++ b/7.3-dev/Dockerfile
@@ -120,6 +120,8 @@ RUN apt-get update \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # XDebug
+# TODO: Remove xdebug next time it causes problems. It is a lot of effort
+# to maintain, and no one is actually using it.
 RUN pecl install xdebug \
   && docker-php-ext-enable xdebug \
   && echo "xdebug.mode=debug" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/7.3-dev/Dockerfile
+++ b/7.3-dev/Dockerfile
@@ -113,6 +113,8 @@ RUN apt-get update \
   && echo "deb-src https://deb.nodesource.com/node_$NODE_MAJOR_VERSION.x $(lsb_release --codename | cut -f2) main" >> /etc/apt/sources.list.d/nodesource.list \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
   && apt-get update \
+  # Force apt to use the deb.nodesource repository
+  && echo "Package: nodejs\nPin: origin deb.nodesource.com\nPin-priority: 1000" > /etc/apt/preferences.d/99-nodejs \
   && apt-get install -y nodejs \
   && apt-get install -y --no-install-recommends yarn \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/7.3-dev/scripts/docker-php-entrypoint
+++ b/7.3-dev/scripts/docker-php-entrypoint
@@ -4,7 +4,9 @@ set -e
 # Write overrides to PHP and Apache. This is incompatible with starting the container
 # with any user other than root, but that's not advised for the PHP Apache container
 # anyway.
-dockerize \
+php_at_least_7_3=$(php -r 'echo version_compare(PHP_VERSION, "7.3") >= 0;')
+
+PHP_AT_LEAST_7_3=$php_at_least_7_3 dockerize \
   -template /templates/php.overrides.tmpl:$PHP_INI_DIR/conf.d/99-runtime.ini \
   -template /templates/mpm_prefork.conf.tmpl:/etc/apache2/mods-enabled/mpm_prefork.conf
 

--- a/7.3-dev/scripts/docker-php-entrypoint
+++ b/7.3-dev/scripts/docker-php-entrypoint
@@ -4,6 +4,9 @@ set -e
 # Write overrides to PHP and Apache. This is incompatible with starting the container
 # with any user other than root, but that's not advised for the PHP Apache container
 # anyway.
+
+# PHP 7.3 is the first version that uses Xdebug 3; it's easier to check
+# the php version in here than the Xdebug version
 php_at_least_7_3=$(php -r 'echo version_compare(PHP_VERSION, "7.3") >= 0;')
 
 PHP_AT_LEAST_7_3=$php_at_least_7_3 dockerize \

--- a/7.3-dev/templates/php.overrides.tmpl
+++ b/7.3-dev/templates/php.overrides.tmpl
@@ -10,8 +10,14 @@ date.timezone={{ default .Env.TZ "UTC" }}
 
 ; XDebug can be conditionally triggered.
 {{ if .Env.XDEBUG_ENABLE }}
+{{ if .Env.PHP_AT_LEAST_7_3 }}
+xdebug.client_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
+xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
+xdebug.start_with_request={{ default .Env.XDEBUG_START_WITH_REQUEST "yes" }}
+{{ else }}
 xdebug.remote_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
 xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
 xdebug.remote_enable={{ default .Env.XDEBUG_REMOTE_ENABLE "On" }}
 xdebug.remote_autostart={{ default .Env.XDEBUG_REMOTE_AUTOSTART "On" }}
+{{ end }}
 {{ end }}

--- a/7.3-dev/test.yml
+++ b/7.3-dev/test.yml
@@ -57,13 +57,15 @@ commandTests:
       - {key: XDEBUG_ENABLE, value: True }
       - {key: XDEBUG_REMOTE_HOST, value: foo.bar}
       - {key: XDEBUG_IDEKEY, value: foobar}
-      - {key: XDEBUG_REMOTE_ENABLE, value: 1}
-      - {key: XDEBUG_REMOTE_AUTOSTART, value: 1}
+
+      - {key: XDEBUG_START_WITH_REQUEST, value: "yes"}
+
     expectedOutput:
-      - xdebug.remote_autostart => On => On
-      - xdebug.remote_enable => On => On
-      - xdebug.remote_host => foo.bar => foo.bar
       - xdebug.idekey => foobar => foobar
+
+      - xdebug.start_with_request => yes => yes
+      - xdebug.client_host => foo.bar => foo.bar
+
   - name: "NodeJS Should be installed and in the correct version"
     command: "node"
     args: ["--version"]

--- a/7.3-dev/test.yml
+++ b/7.3-dev/test.yml
@@ -18,7 +18,7 @@ commandTests:
     args: ["-i"]
     expectedOutput:
       - memory_limit => 128M => 128M
-      - sendmail_path =>  -t -i  =>  -t -i
+      - sendmail_path => (?:\/usr\/sbin\/sendmail)? -t -i\s*=> (?:\/usr\/sbin\/sendmail)? -t -i
       - date.timezone => UTC => UTC
   - name: "Composer should work"
     command: composer

--- a/7.3/scripts/docker-php-entrypoint
+++ b/7.3/scripts/docker-php-entrypoint
@@ -4,7 +4,9 @@ set -e
 # Write overrides to PHP and Apache. This is incompatible with starting the container
 # with any user other than root, but that's not advised for the PHP Apache container
 # anyway.
-dockerize \
+php_at_least_7_3=$(php -r 'echo version_compare(PHP_VERSION, "7.3") >= 0;')
+
+PHP_AT_LEAST_7_3=$php_at_least_7_3 dockerize \
   -template /templates/php.overrides.tmpl:$PHP_INI_DIR/conf.d/99-runtime.ini \
   -template /templates/mpm_prefork.conf.tmpl:/etc/apache2/mods-enabled/mpm_prefork.conf
 

--- a/7.3/scripts/docker-php-entrypoint
+++ b/7.3/scripts/docker-php-entrypoint
@@ -4,6 +4,9 @@ set -e
 # Write overrides to PHP and Apache. This is incompatible with starting the container
 # with any user other than root, but that's not advised for the PHP Apache container
 # anyway.
+
+# PHP 7.3 is the first version that uses Xdebug 3; it's easier to check
+# the php version in here than the Xdebug version
 php_at_least_7_3=$(php -r 'echo version_compare(PHP_VERSION, "7.3") >= 0;')
 
 PHP_AT_LEAST_7_3=$php_at_least_7_3 dockerize \

--- a/7.3/templates/php.overrides.tmpl
+++ b/7.3/templates/php.overrides.tmpl
@@ -10,8 +10,14 @@ date.timezone={{ default .Env.TZ "UTC" }}
 
 ; XDebug can be conditionally triggered.
 {{ if .Env.XDEBUG_ENABLE }}
+{{ if .Env.PHP_AT_LEAST_7_3 }}
+xdebug.client_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
+xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
+xdebug.start_with_request={{ default .Env.XDEBUG_START_WITH_REQUEST "yes" }}
+{{ else }}
 xdebug.remote_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
 xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
 xdebug.remote_enable={{ default .Env.XDEBUG_REMOTE_ENABLE "On" }}
 xdebug.remote_autostart={{ default .Env.XDEBUG_REMOTE_AUTOSTART "On" }}
+{{ end }}
 {{ end }}

--- a/7.3/test.yml
+++ b/7.3/test.yml
@@ -18,7 +18,7 @@ commandTests:
     args: ["-i"]
     expectedOutput:
       - memory_limit => 128M => 128M
-      - sendmail_path =>  -t -i  =>  -t -i
+      - sendmail_path => (?:\/usr\/sbin\/sendmail)? -t -i\s*=> (?:\/usr\/sbin\/sendmail)? -t -i
       - date.timezone => UTC => UTC
   - name: "Composer should work"
     command: composer

--- a/7.4-dev/Dockerfile
+++ b/7.4-dev/Dockerfile
@@ -120,7 +120,8 @@ RUN apt-get update \
 # XDebug
 RUN pecl install xdebug \
   && docker-php-ext-enable xdebug \
-  && echo "xdebug.default_enable=0\nxdebug.coverage_enable=0" > $PHP_INI_DIR/conf.d/xdebug.ini
+  && echo "xdebug.mode=debug" > $PHP_INI_DIR/conf.d/xdebug.ini
+
 
 # Blackfire Probe. Note: We do not install Blackfire CLI. You will
 # need that in order to trigger Blackfire tests. The probe just instruments

--- a/7.4-dev/Dockerfile
+++ b/7.4-dev/Dockerfile
@@ -120,6 +120,8 @@ RUN apt-get update \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # XDebug
+# TODO: Remove xdebug next time it causes problems. It is a lot of effort
+# to maintain, and no one is actually using it.
 RUN pecl install xdebug \
   && docker-php-ext-enable xdebug \
   && echo "xdebug.mode=debug" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/7.4-dev/Dockerfile
+++ b/7.4-dev/Dockerfile
@@ -113,6 +113,8 @@ RUN apt-get update \
   && echo "deb-src https://deb.nodesource.com/node_$NODE_MAJOR_VERSION.x $(lsb_release --codename | cut -f2) main" >> /etc/apt/sources.list.d/nodesource.list \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
   && apt-get update \
+  # Force apt to use the deb.nodesource repository
+  && echo "Package: nodejs\nPin: origin deb.nodesource.com\nPin-priority: 1000" > /etc/apt/preferences.d/99-nodejs \
   && apt-get install -y nodejs \
   && apt-get install -y --no-install-recommends yarn \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/7.4-dev/scripts/docker-php-entrypoint
+++ b/7.4-dev/scripts/docker-php-entrypoint
@@ -4,7 +4,9 @@ set -e
 # Write overrides to PHP and Apache. This is incompatible with starting the container
 # with any user other than root, but that's not advised for the PHP Apache container
 # anyway.
-dockerize \
+php_at_least_7_3=$(php -r 'echo version_compare(PHP_VERSION, "7.3") >= 0;')
+
+PHP_AT_LEAST_7_3=$php_at_least_7_3 dockerize \
   -template /templates/php.overrides.tmpl:$PHP_INI_DIR/conf.d/99-runtime.ini \
   -template /templates/mpm_prefork.conf.tmpl:/etc/apache2/mods-enabled/mpm_prefork.conf
 

--- a/7.4-dev/scripts/docker-php-entrypoint
+++ b/7.4-dev/scripts/docker-php-entrypoint
@@ -4,6 +4,9 @@ set -e
 # Write overrides to PHP and Apache. This is incompatible with starting the container
 # with any user other than root, but that's not advised for the PHP Apache container
 # anyway.
+
+# PHP 7.3 is the first version that uses Xdebug 3; it's easier to check
+# the php version in here than the Xdebug version
 php_at_least_7_3=$(php -r 'echo version_compare(PHP_VERSION, "7.3") >= 0;')
 
 PHP_AT_LEAST_7_3=$php_at_least_7_3 dockerize \

--- a/7.4-dev/templates/php.overrides.tmpl
+++ b/7.4-dev/templates/php.overrides.tmpl
@@ -10,8 +10,14 @@ date.timezone={{ default .Env.TZ "UTC" }}
 
 ; XDebug can be conditionally triggered.
 {{ if .Env.XDEBUG_ENABLE }}
+{{ if .Env.PHP_AT_LEAST_7_3 }}
+xdebug.client_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
+xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
+xdebug.start_with_request={{ default .Env.XDEBUG_START_WITH_REQUEST "yes" }}
+{{ else }}
 xdebug.remote_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
 xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
 xdebug.remote_enable={{ default .Env.XDEBUG_REMOTE_ENABLE "On" }}
 xdebug.remote_autostart={{ default .Env.XDEBUG_REMOTE_AUTOSTART "On" }}
+{{ end }}
 {{ end }}

--- a/7.4-dev/test.yml
+++ b/7.4-dev/test.yml
@@ -57,13 +57,15 @@ commandTests:
       - {key: XDEBUG_ENABLE, value: True }
       - {key: XDEBUG_REMOTE_HOST, value: foo.bar}
       - {key: XDEBUG_IDEKEY, value: foobar}
-      - {key: XDEBUG_REMOTE_ENABLE, value: 1}
-      - {key: XDEBUG_REMOTE_AUTOSTART, value: 1}
+
+      - {key: XDEBUG_START_WITH_REQUEST, value: "yes"}
+
     expectedOutput:
-      - xdebug.remote_autostart => On => On
-      - xdebug.remote_enable => On => On
-      - xdebug.remote_host => foo.bar => foo.bar
       - xdebug.idekey => foobar => foobar
+
+      - xdebug.start_with_request => yes => yes
+      - xdebug.client_host => foo.bar => foo.bar
+
   - name: "NodeJS Should be installed and in the correct version"
     command: "node"
     args: ["--version"]

--- a/7.4-dev/test.yml
+++ b/7.4-dev/test.yml
@@ -18,7 +18,7 @@ commandTests:
     args: ["-i"]
     expectedOutput:
       - memory_limit => 128M => 128M
-      - sendmail_path =>  -t -i  =>  -t -i
+      - sendmail_path => (?:\/usr\/sbin\/sendmail)? -t -i\s*=> (?:\/usr\/sbin\/sendmail)? -t -i
       - date.timezone => UTC => UTC
   - name: "Composer should work"
     command: composer

--- a/7.4/scripts/docker-php-entrypoint
+++ b/7.4/scripts/docker-php-entrypoint
@@ -4,7 +4,9 @@ set -e
 # Write overrides to PHP and Apache. This is incompatible with starting the container
 # with any user other than root, but that's not advised for the PHP Apache container
 # anyway.
-dockerize \
+php_at_least_7_3=$(php -r 'echo version_compare(PHP_VERSION, "7.3") >= 0;')
+
+PHP_AT_LEAST_7_3=$php_at_least_7_3 dockerize \
   -template /templates/php.overrides.tmpl:$PHP_INI_DIR/conf.d/99-runtime.ini \
   -template /templates/mpm_prefork.conf.tmpl:/etc/apache2/mods-enabled/mpm_prefork.conf
 

--- a/7.4/scripts/docker-php-entrypoint
+++ b/7.4/scripts/docker-php-entrypoint
@@ -4,6 +4,9 @@ set -e
 # Write overrides to PHP and Apache. This is incompatible with starting the container
 # with any user other than root, but that's not advised for the PHP Apache container
 # anyway.
+
+# PHP 7.3 is the first version that uses Xdebug 3; it's easier to check
+# the php version in here than the Xdebug version
 php_at_least_7_3=$(php -r 'echo version_compare(PHP_VERSION, "7.3") >= 0;')
 
 PHP_AT_LEAST_7_3=$php_at_least_7_3 dockerize \

--- a/7.4/templates/php.overrides.tmpl
+++ b/7.4/templates/php.overrides.tmpl
@@ -10,8 +10,14 @@ date.timezone={{ default .Env.TZ "UTC" }}
 
 ; XDebug can be conditionally triggered.
 {{ if .Env.XDEBUG_ENABLE }}
+{{ if .Env.PHP_AT_LEAST_7_3 }}
+xdebug.client_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
+xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
+xdebug.start_with_request={{ default .Env.XDEBUG_START_WITH_REQUEST "yes" }}
+{{ else }}
 xdebug.remote_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
 xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
 xdebug.remote_enable={{ default .Env.XDEBUG_REMOTE_ENABLE "On" }}
 xdebug.remote_autostart={{ default .Env.XDEBUG_REMOTE_AUTOSTART "On" }}
+{{ end }}
 {{ end }}

--- a/7.4/test.yml
+++ b/7.4/test.yml
@@ -18,7 +18,7 @@ commandTests:
     args: ["-i"]
     expectedOutput:
       - memory_limit => 128M => 128M
-      - sendmail_path =>  -t -i  =>  -t -i
+      - sendmail_path => (?:\/usr\/sbin\/sendmail)? -t -i\s*=> (?:\/usr\/sbin\/sendmail)? -t -i
       - date.timezone => UTC => UTC
   - name: "Composer should work"
     command: composer

--- a/8.0-dev/Dockerfile
+++ b/8.0-dev/Dockerfile
@@ -120,7 +120,8 @@ RUN apt-get update \
 # XDebug
 RUN pecl install xdebug \
   && docker-php-ext-enable xdebug \
-  && echo "xdebug.default_enable=0\nxdebug.coverage_enable=0" > $PHP_INI_DIR/conf.d/xdebug.ini
+  && echo "xdebug.mode=debug" > $PHP_INI_DIR/conf.d/xdebug.ini
+
 
 # Blackfire Probe. Note: We do not install Blackfire CLI. You will
 # need that in order to trigger Blackfire tests. The probe just instruments

--- a/8.0-dev/Dockerfile
+++ b/8.0-dev/Dockerfile
@@ -120,6 +120,8 @@ RUN apt-get update \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # XDebug
+# TODO: Remove xdebug next time it causes problems. It is a lot of effort
+# to maintain, and no one is actually using it.
 RUN pecl install xdebug \
   && docker-php-ext-enable xdebug \
   && echo "xdebug.mode=debug" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/8.0-dev/Dockerfile
+++ b/8.0-dev/Dockerfile
@@ -113,6 +113,8 @@ RUN apt-get update \
   && echo "deb-src https://deb.nodesource.com/node_$NODE_MAJOR_VERSION.x $(lsb_release --codename | cut -f2) main" >> /etc/apt/sources.list.d/nodesource.list \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
   && apt-get update \
+  # Force apt to use the deb.nodesource repository
+  && echo "Package: nodejs\nPin: origin deb.nodesource.com\nPin-priority: 1000" > /etc/apt/preferences.d/99-nodejs \
   && apt-get install -y nodejs \
   && apt-get install -y --no-install-recommends yarn \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/8.0-dev/Dockerfile
+++ b/8.0-dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:{{ .Env.PHP_VERSION }}-apache
+FROM php:8.0-apache
 
 # common-php70
 ENV DEBIAN_FRONTEND noninteractive
@@ -37,7 +37,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       unzip \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN docker-php-ext-configure gd {{if (not (atoi .Env.PHP_AT_LEAST_7_4))}}--with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/{{ end }} \
+RUN docker-php-ext-configure gd  \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu \
     && docker-php-ext-install -j$(nproc) \
       bcmath \
@@ -71,7 +71,7 @@ RUN a2enmod rewrite headers expires \
 
 # Install Composer.
 
-ARG COMPOSER_VERSION={{ .Env.COMPOSER_VERSION }}
+ARG COMPOSER_VERSION=2.3.10
 RUN COMPOSER_SHA384=$(curl https://composer.github.io/installer.sig) \
   && curl -fsSL -o composer-setup.php https://getcomposer.org/installer \
   && echo "$COMPOSER_SHA384 composer-setup.php" | sha384sum -c - \
@@ -102,9 +102,9 @@ ADD templates /templates
 ADD scripts/* /usr/local/bin/
 
 # /common-php70
-{{ if .Env.IS_DEV }}
+
 # NodeJS + Yarn
-ARG NODE_MAJOR_VERSION={{ .Env.NODE_MAJOR_VERSION }}
+ARG NODE_MAJOR_VERSION=16
 RUN apt-get update \
   && apt-get install -y apt-transport-https lsb-release gnupg > /dev/null 2>&1 \
   && curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
@@ -118,7 +118,7 @@ RUN apt-get update \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # XDebug
-RUN pecl install xdebug{{ .Env.XDEBUG_VERSION_STRING }} \
+RUN pecl install xdebug \
   && docker-php-ext-enable xdebug \
   && echo "xdebug.default_enable=0\nxdebug.coverage_enable=0" > $PHP_INI_DIR/conf.d/xdebug.ini
 
@@ -148,4 +148,4 @@ RUN npm i --no-cache -g gulp-cli
 RUN apt-get update \
   && apt-get install -y imagemagick > /dev/null 2>&1 \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-{{ end }}
+

--- a/8.0-dev/Dockerfile
+++ b/8.0-dev/Dockerfile
@@ -134,8 +134,8 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
 
 # Terminus.
-ARG TERMINUS_VERSION=2.2.0
-ARG TERMINUS_SHA256="73fcdf6ceee23731c20bff45f668bde09230af347670a92e5ca97c2c008ae6e0"
+ARG TERMINUS_VERSION=3.0.7
+ARG TERMINUS_SHA256="f8fd66afb825ba2314a3c1d9a0b0e7e3dedbe687668613bd511ff6b41c4c6516"
 RUN curl -fsSOL https://github.com/pantheon-systems/terminus/releases/download/$TERMINUS_VERSION/terminus.phar \
   && echo "$TERMINUS_SHA256 terminus.phar" | sha256sum -c - \
   && mv terminus.phar /usr/local/bin/terminus \

--- a/8.0-dev/scripts/check-apache-mem
+++ b/8.0-dev/scripts/check-apache-mem
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+ps -ylC apache2 | awk '{x += $8;y += 1} END {print "Apache Memory Usage (MB): "x/1024; print "Average Process Size (MB): "x/((y-1)*1024)}'

--- a/8.0-dev/scripts/docker-php-entrypoint
+++ b/8.0-dev/scripts/docker-php-entrypoint
@@ -4,7 +4,9 @@ set -e
 # Write overrides to PHP and Apache. This is incompatible with starting the container
 # with any user other than root, but that's not advised for the PHP Apache container
 # anyway.
-dockerize \
+php_at_least_7_3=$(php -r 'echo version_compare(PHP_VERSION, "7.3") >= 0;')
+
+PHP_AT_LEAST_7_3=$php_at_least_7_3 dockerize \
   -template /templates/php.overrides.tmpl:$PHP_INI_DIR/conf.d/99-runtime.ini \
   -template /templates/mpm_prefork.conf.tmpl:/etc/apache2/mods-enabled/mpm_prefork.conf
 

--- a/8.0-dev/scripts/docker-php-entrypoint
+++ b/8.0-dev/scripts/docker-php-entrypoint
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+
+# Write overrides to PHP and Apache. This is incompatible with starting the container
+# with any user other than root, but that's not advised for the PHP Apache container
+# anyway.
+dockerize \
+  -template /templates/php.overrides.tmpl:$PHP_INI_DIR/conf.d/99-runtime.ini \
+  -template /templates/mpm_prefork.conf.tmpl:/etc/apache2/mods-enabled/mpm_prefork.conf
+
+# Toggle XDebug completely on and off at runtime
+# Enable Xdebug by setting XDEBUG_ENABLE=1.
+if [ -z "$XDEBUG_ENABLE" ] || [ "$XDEBUG_ENABLE" -eq "0" ]; then
+  rm -f $PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini
+else
+  docker-php-ext-enable xdebug
+fi
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- apache2-foreground "$@"
+fi
+exec "$@"

--- a/8.0-dev/scripts/docker-php-entrypoint
+++ b/8.0-dev/scripts/docker-php-entrypoint
@@ -4,6 +4,9 @@ set -e
 # Write overrides to PHP and Apache. This is incompatible with starting the container
 # with any user other than root, but that's not advised for the PHP Apache container
 # anyway.
+
+# PHP 7.3 is the first version that uses Xdebug 3; it's easier to check
+# the php version in here than the Xdebug version
 php_at_least_7_3=$(php -r 'echo version_compare(PHP_VERSION, "7.3") >= 0;')
 
 PHP_AT_LEAST_7_3=$php_at_least_7_3 dockerize \

--- a/8.0-dev/templates/mpm_prefork.conf.tmpl
+++ b/8.0-dev/templates/mpm_prefork.conf.tmpl
@@ -1,0 +1,8 @@
+# Allow overriding some settings to control performance.
+<IfModule mpm_prefork_module>
+	StartServers			 5
+	MinSpareServers		  5
+	MaxSpareServers		 10
+	MaxRequestWorkers	  {{ default .Env.APACHE_REQUEST_WORKERS "150" }}
+	MaxConnectionsPerChild   5000
+</IfModule>

--- a/8.0-dev/templates/php.overrides.tmpl
+++ b/8.0-dev/templates/php.overrides.tmpl
@@ -10,8 +10,14 @@ date.timezone={{ default .Env.TZ "UTC" }}
 
 ; XDebug can be conditionally triggered.
 {{ if .Env.XDEBUG_ENABLE }}
+{{ if .Env.PHP_AT_LEAST_7_3 }}
+xdebug.client_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
+xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
+xdebug.start_with_request={{ default .Env.XDEBUG_START_WITH_REQUEST "yes" }}
+{{ else }}
 xdebug.remote_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
 xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
 xdebug.remote_enable={{ default .Env.XDEBUG_REMOTE_ENABLE "On" }}
 xdebug.remote_autostart={{ default .Env.XDEBUG_REMOTE_AUTOSTART "On" }}
+{{ end }}
 {{ end }}

--- a/8.0-dev/templates/php.overrides.tmpl
+++ b/8.0-dev/templates/php.overrides.tmpl
@@ -1,0 +1,17 @@
+; Set a reasonable max upload size
+upload_max_filesize = 128M
+post_max_size = 128M
+
+; These settings can be overridden at runtime by the presence of environment
+; variables.
+date.timezone={{ default .Env.TZ "UTC" }}
+{{ if .Env.PHP_MEMORY_LIMIT }}memory_limit={{ .Env.PHP_MEMORY_LIMIT }}{{ end }}
+{{ if .Env.SENDMAIL_PATH }}sendmail_path={{ .Env.SENDMAIL_PATH }}{{ end }}
+
+; XDebug can be conditionally triggered.
+{{ if .Env.XDEBUG_ENABLE }}
+xdebug.remote_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
+xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
+xdebug.remote_enable={{ default .Env.XDEBUG_REMOTE_ENABLE "On" }}
+xdebug.remote_autostart={{ default .Env.XDEBUG_REMOTE_AUTOSTART "On" }}
+{{ end }}

--- a/8.0-dev/test.yml
+++ b/8.0-dev/test.yml
@@ -28,7 +28,7 @@ commandTests:
     args: ["--drush-launcher-version"]
     expectedOutput:
       - "Drush Launcher Version: 0.6.0"
-{{if .Env.IS_DEV}}
+
   - name: "Blackfire agent should be present and configured"
     command: "php"
     args: ["-i"]
@@ -68,11 +68,11 @@ commandTests:
     command: "node"
     args: ["--version"]
     expectedOutput:
-      - v{{ .Env.NODE_MAJOR_VERSION }}.
+      - v16.
   - name: "Yarn should be installed and functional"
     command: "yarn"
     args: ["--version"]
   - name: "Terminus should be installed and functional"
     command: "terminus"
     args: ["self:info"]
-{{ end }}
+

--- a/8.0-dev/test.yml
+++ b/8.0-dev/test.yml
@@ -57,13 +57,15 @@ commandTests:
       - {key: XDEBUG_ENABLE, value: True }
       - {key: XDEBUG_REMOTE_HOST, value: foo.bar}
       - {key: XDEBUG_IDEKEY, value: foobar}
-      - {key: XDEBUG_REMOTE_ENABLE, value: 1}
-      - {key: XDEBUG_REMOTE_AUTOSTART, value: 1}
+
+      - {key: XDEBUG_START_WITH_REQUEST, value: "yes"}
+
     expectedOutput:
-      - xdebug.remote_autostart => On => On
-      - xdebug.remote_enable => On => On
-      - xdebug.remote_host => foo.bar => foo.bar
       - xdebug.idekey => foobar => foobar
+
+      - xdebug.start_with_request => yes => yes
+      - xdebug.client_host => foo.bar => foo.bar
+
   - name: "NodeJS Should be installed and in the correct version"
     command: "node"
     args: ["--version"]

--- a/8.0-dev/test.yml
+++ b/8.0-dev/test.yml
@@ -18,7 +18,7 @@ commandTests:
     args: ["-i"]
     expectedOutput:
       - memory_limit => 128M => 128M
-      - sendmail_path =>  -t -i  =>  -t -i
+      - sendmail_path => (?:\/usr\/sbin\/sendmail)? -t -i\s*=> (?:\/usr\/sbin\/sendmail)? -t -i
       - date.timezone => UTC => UTC
   - name: "Composer should work"
     command: composer

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:{{ .Env.PHP_VERSION }}-apache
+FROM php:8.0-apache
 
 # common-php70
 ENV DEBIAN_FRONTEND noninteractive
@@ -37,7 +37,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       unzip \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN docker-php-ext-configure gd {{if (not (atoi .Env.PHP_AT_LEAST_7_4))}}--with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/{{ end }} \
+RUN docker-php-ext-configure gd  \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu \
     && docker-php-ext-install -j$(nproc) \
       bcmath \
@@ -71,7 +71,7 @@ RUN a2enmod rewrite headers expires \
 
 # Install Composer.
 
-ARG COMPOSER_VERSION={{ .Env.COMPOSER_VERSION }}
+ARG COMPOSER_VERSION=2.3.10
 RUN COMPOSER_SHA384=$(curl https://composer.github.io/installer.sig) \
   && curl -fsSL -o composer-setup.php https://getcomposer.org/installer \
   && echo "$COMPOSER_SHA384 composer-setup.php" | sha384sum -c - \
@@ -102,50 +102,4 @@ ADD templates /templates
 ADD scripts/* /usr/local/bin/
 
 # /common-php70
-{{ if .Env.IS_DEV }}
-# NodeJS + Yarn
-ARG NODE_MAJOR_VERSION={{ .Env.NODE_MAJOR_VERSION }}
-RUN apt-get update \
-  && apt-get install -y apt-transport-https lsb-release gnupg > /dev/null 2>&1 \
-  && curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
-  && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-  && echo "deb https://deb.nodesource.com/node_$NODE_MAJOR_VERSION.x $(lsb_release --codename | cut -f2) main" > /etc/apt/sources.list.d/nodesource.list \
-  && echo "deb-src https://deb.nodesource.com/node_$NODE_MAJOR_VERSION.x $(lsb_release --codename | cut -f2) main" >> /etc/apt/sources.list.d/nodesource.list \
-  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
-  && apt-get update \
-  && apt-get install -y nodejs \
-  && apt-get install -y --no-install-recommends yarn \
-  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# XDebug
-RUN pecl install xdebug{{ .Env.XDEBUG_VERSION_STRING }} \
-  && docker-php-ext-enable xdebug \
-  && echo "xdebug.default_enable=0\nxdebug.coverage_enable=0" > $PHP_INI_DIR/conf.d/xdebug.ini
-
-# Blackfire Probe. Note: We do not install Blackfire CLI. You will
-# need that in order to trigger Blackfire tests. The probe just instruments
-# things on the server side.
-RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
-    && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
-    && mkdir -p /tmp/blackfire \
-    && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire \
-    && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
-    && printf "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8707\n" > $PHP_INI_DIR/conf.d/blackfire.ini \
-    && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
-
-# Terminus.
-ARG TERMINUS_VERSION=2.2.0
-ARG TERMINUS_SHA256="73fcdf6ceee23731c20bff45f668bde09230af347670a92e5ca97c2c008ae6e0"
-RUN curl -fsSOL https://github.com/pantheon-systems/terminus/releases/download/$TERMINUS_VERSION/terminus.phar \
-  && echo "$TERMINUS_SHA256 terminus.phar" | sha256sum -c - \
-  && mv terminus.phar /usr/local/bin/terminus \
-  && chmod +x /usr/local/bin/terminus
-
-# Gulp-cli.
-RUN npm i --no-cache -g gulp-cli
-
-# ImageMagick
-RUN apt-get update \
-  && apt-get install -y imagemagick > /dev/null 2>&1 \
-  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-{{ end }}

--- a/8.0/scripts/check-apache-mem
+++ b/8.0/scripts/check-apache-mem
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+ps -ylC apache2 | awk '{x += $8;y += 1} END {print "Apache Memory Usage (MB): "x/1024; print "Average Process Size (MB): "x/((y-1)*1024)}'

--- a/8.0/scripts/docker-php-entrypoint
+++ b/8.0/scripts/docker-php-entrypoint
@@ -4,7 +4,9 @@ set -e
 # Write overrides to PHP and Apache. This is incompatible with starting the container
 # with any user other than root, but that's not advised for the PHP Apache container
 # anyway.
-dockerize \
+php_at_least_7_3=$(php -r 'echo version_compare(PHP_VERSION, "7.3") >= 0;')
+
+PHP_AT_LEAST_7_3=$php_at_least_7_3 dockerize \
   -template /templates/php.overrides.tmpl:$PHP_INI_DIR/conf.d/99-runtime.ini \
   -template /templates/mpm_prefork.conf.tmpl:/etc/apache2/mods-enabled/mpm_prefork.conf
 

--- a/8.0/scripts/docker-php-entrypoint
+++ b/8.0/scripts/docker-php-entrypoint
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+
+# Write overrides to PHP and Apache. This is incompatible with starting the container
+# with any user other than root, but that's not advised for the PHP Apache container
+# anyway.
+dockerize \
+  -template /templates/php.overrides.tmpl:$PHP_INI_DIR/conf.d/99-runtime.ini \
+  -template /templates/mpm_prefork.conf.tmpl:/etc/apache2/mods-enabled/mpm_prefork.conf
+
+# Toggle XDebug completely on and off at runtime
+# Enable Xdebug by setting XDEBUG_ENABLE=1.
+if [ -z "$XDEBUG_ENABLE" ] || [ "$XDEBUG_ENABLE" -eq "0" ]; then
+  rm -f $PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini
+else
+  docker-php-ext-enable xdebug
+fi
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- apache2-foreground "$@"
+fi
+exec "$@"

--- a/8.0/scripts/docker-php-entrypoint
+++ b/8.0/scripts/docker-php-entrypoint
@@ -4,6 +4,9 @@ set -e
 # Write overrides to PHP and Apache. This is incompatible with starting the container
 # with any user other than root, but that's not advised for the PHP Apache container
 # anyway.
+
+# PHP 7.3 is the first version that uses Xdebug 3; it's easier to check
+# the php version in here than the Xdebug version
 php_at_least_7_3=$(php -r 'echo version_compare(PHP_VERSION, "7.3") >= 0;')
 
 PHP_AT_LEAST_7_3=$php_at_least_7_3 dockerize \

--- a/8.0/templates/mpm_prefork.conf.tmpl
+++ b/8.0/templates/mpm_prefork.conf.tmpl
@@ -1,0 +1,8 @@
+# Allow overriding some settings to control performance.
+<IfModule mpm_prefork_module>
+	StartServers			 5
+	MinSpareServers		  5
+	MaxSpareServers		 10
+	MaxRequestWorkers	  {{ default .Env.APACHE_REQUEST_WORKERS "150" }}
+	MaxConnectionsPerChild   5000
+</IfModule>

--- a/8.0/templates/php.overrides.tmpl
+++ b/8.0/templates/php.overrides.tmpl
@@ -10,8 +10,14 @@ date.timezone={{ default .Env.TZ "UTC" }}
 
 ; XDebug can be conditionally triggered.
 {{ if .Env.XDEBUG_ENABLE }}
+{{ if .Env.PHP_AT_LEAST_7_3 }}
+xdebug.client_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
+xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
+xdebug.start_with_request={{ default .Env.XDEBUG_START_WITH_REQUEST "yes" }}
+{{ else }}
 xdebug.remote_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
 xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
 xdebug.remote_enable={{ default .Env.XDEBUG_REMOTE_ENABLE "On" }}
 xdebug.remote_autostart={{ default .Env.XDEBUG_REMOTE_AUTOSTART "On" }}
+{{ end }}
 {{ end }}

--- a/8.0/templates/php.overrides.tmpl
+++ b/8.0/templates/php.overrides.tmpl
@@ -1,0 +1,17 @@
+; Set a reasonable max upload size
+upload_max_filesize = 128M
+post_max_size = 128M
+
+; These settings can be overridden at runtime by the presence of environment
+; variables.
+date.timezone={{ default .Env.TZ "UTC" }}
+{{ if .Env.PHP_MEMORY_LIMIT }}memory_limit={{ .Env.PHP_MEMORY_LIMIT }}{{ end }}
+{{ if .Env.SENDMAIL_PATH }}sendmail_path={{ .Env.SENDMAIL_PATH }}{{ end }}
+
+; XDebug can be conditionally triggered.
+{{ if .Env.XDEBUG_ENABLE }}
+xdebug.remote_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
+xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
+xdebug.remote_enable={{ default .Env.XDEBUG_REMOTE_ENABLE "On" }}
+xdebug.remote_autostart={{ default .Env.XDEBUG_REMOTE_AUTOSTART "On" }}
+{{ end }}

--- a/8.0/test.yml
+++ b/8.0/test.yml
@@ -1,0 +1,31 @@
+schemaVersion: "2.0.0"
+commandTests:
+  - name: "php should be configurable by environment variables"
+    setup: [["docker-php-entrypoint"]]
+    envVars:
+      - {key: PHP_MEMORY_LIMIT, value: 512M }
+      - {key: SENDMAIL_PATH, value: /bin/true }
+      - {key: TZ, value: America/New_York }
+    command: "php"
+    args: ["-i"]
+    expectedOutput:
+      - memory_limit => 512M => 512M
+      - sendmail_path => /bin/true => /bin/true
+      - date.timezone => America/New_York => America/New_York
+  - name: "php should use have default values"
+    setup: [["docker-php-entrypoint"]]
+    command: "php"
+    args: ["-i"]
+    expectedOutput:
+      - memory_limit => 128M => 128M
+      - sendmail_path =>  -t -i  =>  -t -i
+      - date.timezone => UTC => UTC
+  - name: "Composer should work"
+    command: composer
+    args: ["diagnose"]
+  - name: "Drush should be launchable"
+    command: drush
+    args: ["--drush-launcher-version"]
+    expectedOutput:
+      - "Drush Launcher Version: 0.6.0"
+

--- a/8.0/test.yml
+++ b/8.0/test.yml
@@ -18,7 +18,7 @@ commandTests:
     args: ["-i"]
     expectedOutput:
       - memory_limit => 128M => 128M
-      - sendmail_path =>  -t -i  =>  -t -i
+      - sendmail_path => (?:\/usr\/sbin\/sendmail)? -t -i\s*=> (?:\/usr\/sbin\/sendmail)? -t -i
       - date.timezone => UTC => UTC
   - name: "Composer should work"
     command: composer

--- a/8.1-dev/Dockerfile
+++ b/8.1-dev/Dockerfile
@@ -120,7 +120,8 @@ RUN apt-get update \
 # XDebug
 RUN pecl install xdebug \
   && docker-php-ext-enable xdebug \
-  && echo "xdebug.default_enable=0\nxdebug.coverage_enable=0" > $PHP_INI_DIR/conf.d/xdebug.ini
+  && echo "xdebug.mode=debug" > $PHP_INI_DIR/conf.d/xdebug.ini
+
 
 # Blackfire Probe. Note: We do not install Blackfire CLI. You will
 # need that in order to trigger Blackfire tests. The probe just instruments

--- a/8.1-dev/Dockerfile
+++ b/8.1-dev/Dockerfile
@@ -120,6 +120,8 @@ RUN apt-get update \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # XDebug
+# TODO: Remove xdebug next time it causes problems. It is a lot of effort
+# to maintain, and no one is actually using it.
 RUN pecl install xdebug \
   && docker-php-ext-enable xdebug \
   && echo "xdebug.mode=debug" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/8.1-dev/Dockerfile
+++ b/8.1-dev/Dockerfile
@@ -113,6 +113,8 @@ RUN apt-get update \
   && echo "deb-src https://deb.nodesource.com/node_$NODE_MAJOR_VERSION.x $(lsb_release --codename | cut -f2) main" >> /etc/apt/sources.list.d/nodesource.list \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
   && apt-get update \
+  # Force apt to use the deb.nodesource repository
+  && echo "Package: nodejs\nPin: origin deb.nodesource.com\nPin-priority: 1000" > /etc/apt/preferences.d/99-nodejs \
   && apt-get install -y nodejs \
   && apt-get install -y --no-install-recommends yarn \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/8.1-dev/Dockerfile
+++ b/8.1-dev/Dockerfile
@@ -134,8 +134,8 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
 
 # Terminus.
-ARG TERMINUS_VERSION=2.2.0
-ARG TERMINUS_SHA256="73fcdf6ceee23731c20bff45f668bde09230af347670a92e5ca97c2c008ae6e0"
+ARG TERMINUS_VERSION=3.0.7
+ARG TERMINUS_SHA256="f8fd66afb825ba2314a3c1d9a0b0e7e3dedbe687668613bd511ff6b41c4c6516"
 RUN curl -fsSOL https://github.com/pantheon-systems/terminus/releases/download/$TERMINUS_VERSION/terminus.phar \
   && echo "$TERMINUS_SHA256 terminus.phar" | sha256sum -c - \
   && mv terminus.phar /usr/local/bin/terminus \

--- a/8.1-dev/Dockerfile
+++ b/8.1-dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:{{ .Env.PHP_VERSION }}-apache
+FROM php:8.1-apache
 
 # common-php70
 ENV DEBIAN_FRONTEND noninteractive
@@ -37,7 +37,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       unzip \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN docker-php-ext-configure gd {{if (not (atoi .Env.PHP_AT_LEAST_7_4))}}--with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/{{ end }} \
+RUN docker-php-ext-configure gd  \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu \
     && docker-php-ext-install -j$(nproc) \
       bcmath \
@@ -71,7 +71,7 @@ RUN a2enmod rewrite headers expires \
 
 # Install Composer.
 
-ARG COMPOSER_VERSION={{ .Env.COMPOSER_VERSION }}
+ARG COMPOSER_VERSION=2.3.10
 RUN COMPOSER_SHA384=$(curl https://composer.github.io/installer.sig) \
   && curl -fsSL -o composer-setup.php https://getcomposer.org/installer \
   && echo "$COMPOSER_SHA384 composer-setup.php" | sha384sum -c - \
@@ -102,9 +102,9 @@ ADD templates /templates
 ADD scripts/* /usr/local/bin/
 
 # /common-php70
-{{ if .Env.IS_DEV }}
+
 # NodeJS + Yarn
-ARG NODE_MAJOR_VERSION={{ .Env.NODE_MAJOR_VERSION }}
+ARG NODE_MAJOR_VERSION=16
 RUN apt-get update \
   && apt-get install -y apt-transport-https lsb-release gnupg > /dev/null 2>&1 \
   && curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
@@ -118,7 +118,7 @@ RUN apt-get update \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # XDebug
-RUN pecl install xdebug{{ .Env.XDEBUG_VERSION_STRING }} \
+RUN pecl install xdebug \
   && docker-php-ext-enable xdebug \
   && echo "xdebug.default_enable=0\nxdebug.coverage_enable=0" > $PHP_INI_DIR/conf.d/xdebug.ini
 
@@ -148,4 +148,4 @@ RUN npm i --no-cache -g gulp-cli
 RUN apt-get update \
   && apt-get install -y imagemagick > /dev/null 2>&1 \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-{{ end }}
+

--- a/8.1-dev/scripts/check-apache-mem
+++ b/8.1-dev/scripts/check-apache-mem
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+ps -ylC apache2 | awk '{x += $8;y += 1} END {print "Apache Memory Usage (MB): "x/1024; print "Average Process Size (MB): "x/((y-1)*1024)}'

--- a/8.1-dev/scripts/docker-php-entrypoint
+++ b/8.1-dev/scripts/docker-php-entrypoint
@@ -4,7 +4,9 @@ set -e
 # Write overrides to PHP and Apache. This is incompatible with starting the container
 # with any user other than root, but that's not advised for the PHP Apache container
 # anyway.
-dockerize \
+php_at_least_7_3=$(php -r 'echo version_compare(PHP_VERSION, "7.3") >= 0;')
+
+PHP_AT_LEAST_7_3=$php_at_least_7_3 dockerize \
   -template /templates/php.overrides.tmpl:$PHP_INI_DIR/conf.d/99-runtime.ini \
   -template /templates/mpm_prefork.conf.tmpl:/etc/apache2/mods-enabled/mpm_prefork.conf
 

--- a/8.1-dev/scripts/docker-php-entrypoint
+++ b/8.1-dev/scripts/docker-php-entrypoint
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+
+# Write overrides to PHP and Apache. This is incompatible with starting the container
+# with any user other than root, but that's not advised for the PHP Apache container
+# anyway.
+dockerize \
+  -template /templates/php.overrides.tmpl:$PHP_INI_DIR/conf.d/99-runtime.ini \
+  -template /templates/mpm_prefork.conf.tmpl:/etc/apache2/mods-enabled/mpm_prefork.conf
+
+# Toggle XDebug completely on and off at runtime
+# Enable Xdebug by setting XDEBUG_ENABLE=1.
+if [ -z "$XDEBUG_ENABLE" ] || [ "$XDEBUG_ENABLE" -eq "0" ]; then
+  rm -f $PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini
+else
+  docker-php-ext-enable xdebug
+fi
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- apache2-foreground "$@"
+fi
+exec "$@"

--- a/8.1-dev/scripts/docker-php-entrypoint
+++ b/8.1-dev/scripts/docker-php-entrypoint
@@ -4,6 +4,9 @@ set -e
 # Write overrides to PHP and Apache. This is incompatible with starting the container
 # with any user other than root, but that's not advised for the PHP Apache container
 # anyway.
+
+# PHP 7.3 is the first version that uses Xdebug 3; it's easier to check
+# the php version in here than the Xdebug version
 php_at_least_7_3=$(php -r 'echo version_compare(PHP_VERSION, "7.3") >= 0;')
 
 PHP_AT_LEAST_7_3=$php_at_least_7_3 dockerize \

--- a/8.1-dev/templates/mpm_prefork.conf.tmpl
+++ b/8.1-dev/templates/mpm_prefork.conf.tmpl
@@ -1,0 +1,8 @@
+# Allow overriding some settings to control performance.
+<IfModule mpm_prefork_module>
+	StartServers			 5
+	MinSpareServers		  5
+	MaxSpareServers		 10
+	MaxRequestWorkers	  {{ default .Env.APACHE_REQUEST_WORKERS "150" }}
+	MaxConnectionsPerChild   5000
+</IfModule>

--- a/8.1-dev/templates/php.overrides.tmpl
+++ b/8.1-dev/templates/php.overrides.tmpl
@@ -10,8 +10,14 @@ date.timezone={{ default .Env.TZ "UTC" }}
 
 ; XDebug can be conditionally triggered.
 {{ if .Env.XDEBUG_ENABLE }}
+{{ if .Env.PHP_AT_LEAST_7_3 }}
+xdebug.client_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
+xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
+xdebug.start_with_request={{ default .Env.XDEBUG_START_WITH_REQUEST "yes" }}
+{{ else }}
 xdebug.remote_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
 xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
 xdebug.remote_enable={{ default .Env.XDEBUG_REMOTE_ENABLE "On" }}
 xdebug.remote_autostart={{ default .Env.XDEBUG_REMOTE_AUTOSTART "On" }}
+{{ end }}
 {{ end }}

--- a/8.1-dev/templates/php.overrides.tmpl
+++ b/8.1-dev/templates/php.overrides.tmpl
@@ -1,0 +1,17 @@
+; Set a reasonable max upload size
+upload_max_filesize = 128M
+post_max_size = 128M
+
+; These settings can be overridden at runtime by the presence of environment
+; variables.
+date.timezone={{ default .Env.TZ "UTC" }}
+{{ if .Env.PHP_MEMORY_LIMIT }}memory_limit={{ .Env.PHP_MEMORY_LIMIT }}{{ end }}
+{{ if .Env.SENDMAIL_PATH }}sendmail_path={{ .Env.SENDMAIL_PATH }}{{ end }}
+
+; XDebug can be conditionally triggered.
+{{ if .Env.XDEBUG_ENABLE }}
+xdebug.remote_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
+xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
+xdebug.remote_enable={{ default .Env.XDEBUG_REMOTE_ENABLE "On" }}
+xdebug.remote_autostart={{ default .Env.XDEBUG_REMOTE_AUTOSTART "On" }}
+{{ end }}

--- a/8.1-dev/test.yml
+++ b/8.1-dev/test.yml
@@ -28,7 +28,7 @@ commandTests:
     args: ["--drush-launcher-version"]
     expectedOutput:
       - "Drush Launcher Version: 0.6.0"
-{{if .Env.IS_DEV}}
+
   - name: "Blackfire agent should be present and configured"
     command: "php"
     args: ["-i"]
@@ -68,11 +68,11 @@ commandTests:
     command: "node"
     args: ["--version"]
     expectedOutput:
-      - v{{ .Env.NODE_MAJOR_VERSION }}.
+      - v16.
   - name: "Yarn should be installed and functional"
     command: "yarn"
     args: ["--version"]
   - name: "Terminus should be installed and functional"
     command: "terminus"
     args: ["self:info"]
-{{ end }}
+

--- a/8.1-dev/test.yml
+++ b/8.1-dev/test.yml
@@ -57,13 +57,15 @@ commandTests:
       - {key: XDEBUG_ENABLE, value: True }
       - {key: XDEBUG_REMOTE_HOST, value: foo.bar}
       - {key: XDEBUG_IDEKEY, value: foobar}
-      - {key: XDEBUG_REMOTE_ENABLE, value: 1}
-      - {key: XDEBUG_REMOTE_AUTOSTART, value: 1}
+
+      - {key: XDEBUG_START_WITH_REQUEST, value: "yes"}
+
     expectedOutput:
-      - xdebug.remote_autostart => On => On
-      - xdebug.remote_enable => On => On
-      - xdebug.remote_host => foo.bar => foo.bar
       - xdebug.idekey => foobar => foobar
+
+      - xdebug.start_with_request => yes => yes
+      - xdebug.client_host => foo.bar => foo.bar
+
   - name: "NodeJS Should be installed and in the correct version"
     command: "node"
     args: ["--version"]

--- a/8.1-dev/test.yml
+++ b/8.1-dev/test.yml
@@ -18,7 +18,7 @@ commandTests:
     args: ["-i"]
     expectedOutput:
       - memory_limit => 128M => 128M
-      - sendmail_path =>  -t -i  =>  -t -i
+      - sendmail_path => (?:\/usr\/sbin\/sendmail)? -t -i\s*=> (?:\/usr\/sbin\/sendmail)? -t -i
       - date.timezone => UTC => UTC
   - name: "Composer should work"
     command: composer

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:{{ .Env.PHP_VERSION }}-apache
+FROM php:8.1-apache
 
 # common-php70
 ENV DEBIAN_FRONTEND noninteractive
@@ -37,7 +37,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       unzip \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN docker-php-ext-configure gd {{if (not (atoi .Env.PHP_AT_LEAST_7_4))}}--with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/{{ end }} \
+RUN docker-php-ext-configure gd  \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu \
     && docker-php-ext-install -j$(nproc) \
       bcmath \
@@ -71,7 +71,7 @@ RUN a2enmod rewrite headers expires \
 
 # Install Composer.
 
-ARG COMPOSER_VERSION={{ .Env.COMPOSER_VERSION }}
+ARG COMPOSER_VERSION=2.3.10
 RUN COMPOSER_SHA384=$(curl https://composer.github.io/installer.sig) \
   && curl -fsSL -o composer-setup.php https://getcomposer.org/installer \
   && echo "$COMPOSER_SHA384 composer-setup.php" | sha384sum -c - \
@@ -102,50 +102,4 @@ ADD templates /templates
 ADD scripts/* /usr/local/bin/
 
 # /common-php70
-{{ if .Env.IS_DEV }}
-# NodeJS + Yarn
-ARG NODE_MAJOR_VERSION={{ .Env.NODE_MAJOR_VERSION }}
-RUN apt-get update \
-  && apt-get install -y apt-transport-https lsb-release gnupg > /dev/null 2>&1 \
-  && curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
-  && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-  && echo "deb https://deb.nodesource.com/node_$NODE_MAJOR_VERSION.x $(lsb_release --codename | cut -f2) main" > /etc/apt/sources.list.d/nodesource.list \
-  && echo "deb-src https://deb.nodesource.com/node_$NODE_MAJOR_VERSION.x $(lsb_release --codename | cut -f2) main" >> /etc/apt/sources.list.d/nodesource.list \
-  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
-  && apt-get update \
-  && apt-get install -y nodejs \
-  && apt-get install -y --no-install-recommends yarn \
-  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# XDebug
-RUN pecl install xdebug{{ .Env.XDEBUG_VERSION_STRING }} \
-  && docker-php-ext-enable xdebug \
-  && echo "xdebug.default_enable=0\nxdebug.coverage_enable=0" > $PHP_INI_DIR/conf.d/xdebug.ini
-
-# Blackfire Probe. Note: We do not install Blackfire CLI. You will
-# need that in order to trigger Blackfire tests. The probe just instruments
-# things on the server side.
-RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
-    && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
-    && mkdir -p /tmp/blackfire \
-    && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire \
-    && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
-    && printf "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8707\n" > $PHP_INI_DIR/conf.d/blackfire.ini \
-    && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
-
-# Terminus.
-ARG TERMINUS_VERSION=2.2.0
-ARG TERMINUS_SHA256="73fcdf6ceee23731c20bff45f668bde09230af347670a92e5ca97c2c008ae6e0"
-RUN curl -fsSOL https://github.com/pantheon-systems/terminus/releases/download/$TERMINUS_VERSION/terminus.phar \
-  && echo "$TERMINUS_SHA256 terminus.phar" | sha256sum -c - \
-  && mv terminus.phar /usr/local/bin/terminus \
-  && chmod +x /usr/local/bin/terminus
-
-# Gulp-cli.
-RUN npm i --no-cache -g gulp-cli
-
-# ImageMagick
-RUN apt-get update \
-  && apt-get install -y imagemagick > /dev/null 2>&1 \
-  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-{{ end }}

--- a/8.1/scripts/check-apache-mem
+++ b/8.1/scripts/check-apache-mem
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+ps -ylC apache2 | awk '{x += $8;y += 1} END {print "Apache Memory Usage (MB): "x/1024; print "Average Process Size (MB): "x/((y-1)*1024)}'

--- a/8.1/scripts/docker-php-entrypoint
+++ b/8.1/scripts/docker-php-entrypoint
@@ -4,7 +4,9 @@ set -e
 # Write overrides to PHP and Apache. This is incompatible with starting the container
 # with any user other than root, but that's not advised for the PHP Apache container
 # anyway.
-dockerize \
+php_at_least_7_3=$(php -r 'echo version_compare(PHP_VERSION, "7.3") >= 0;')
+
+PHP_AT_LEAST_7_3=$php_at_least_7_3 dockerize \
   -template /templates/php.overrides.tmpl:$PHP_INI_DIR/conf.d/99-runtime.ini \
   -template /templates/mpm_prefork.conf.tmpl:/etc/apache2/mods-enabled/mpm_prefork.conf
 

--- a/8.1/scripts/docker-php-entrypoint
+++ b/8.1/scripts/docker-php-entrypoint
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+
+# Write overrides to PHP and Apache. This is incompatible with starting the container
+# with any user other than root, but that's not advised for the PHP Apache container
+# anyway.
+dockerize \
+  -template /templates/php.overrides.tmpl:$PHP_INI_DIR/conf.d/99-runtime.ini \
+  -template /templates/mpm_prefork.conf.tmpl:/etc/apache2/mods-enabled/mpm_prefork.conf
+
+# Toggle XDebug completely on and off at runtime
+# Enable Xdebug by setting XDEBUG_ENABLE=1.
+if [ -z "$XDEBUG_ENABLE" ] || [ "$XDEBUG_ENABLE" -eq "0" ]; then
+  rm -f $PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini
+else
+  docker-php-ext-enable xdebug
+fi
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- apache2-foreground "$@"
+fi
+exec "$@"

--- a/8.1/scripts/docker-php-entrypoint
+++ b/8.1/scripts/docker-php-entrypoint
@@ -4,6 +4,9 @@ set -e
 # Write overrides to PHP and Apache. This is incompatible with starting the container
 # with any user other than root, but that's not advised for the PHP Apache container
 # anyway.
+
+# PHP 7.3 is the first version that uses Xdebug 3; it's easier to check
+# the php version in here than the Xdebug version
 php_at_least_7_3=$(php -r 'echo version_compare(PHP_VERSION, "7.3") >= 0;')
 
 PHP_AT_LEAST_7_3=$php_at_least_7_3 dockerize \

--- a/8.1/templates/mpm_prefork.conf.tmpl
+++ b/8.1/templates/mpm_prefork.conf.tmpl
@@ -1,0 +1,8 @@
+# Allow overriding some settings to control performance.
+<IfModule mpm_prefork_module>
+	StartServers			 5
+	MinSpareServers		  5
+	MaxSpareServers		 10
+	MaxRequestWorkers	  {{ default .Env.APACHE_REQUEST_WORKERS "150" }}
+	MaxConnectionsPerChild   5000
+</IfModule>

--- a/8.1/templates/php.overrides.tmpl
+++ b/8.1/templates/php.overrides.tmpl
@@ -10,8 +10,14 @@ date.timezone={{ default .Env.TZ "UTC" }}
 
 ; XDebug can be conditionally triggered.
 {{ if .Env.XDEBUG_ENABLE }}
+{{ if .Env.PHP_AT_LEAST_7_3 }}
+xdebug.client_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
+xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
+xdebug.start_with_request={{ default .Env.XDEBUG_START_WITH_REQUEST "yes" }}
+{{ else }}
 xdebug.remote_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
 xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
 xdebug.remote_enable={{ default .Env.XDEBUG_REMOTE_ENABLE "On" }}
 xdebug.remote_autostart={{ default .Env.XDEBUG_REMOTE_AUTOSTART "On" }}
+{{ end }}
 {{ end }}

--- a/8.1/templates/php.overrides.tmpl
+++ b/8.1/templates/php.overrides.tmpl
@@ -1,0 +1,17 @@
+; Set a reasonable max upload size
+upload_max_filesize = 128M
+post_max_size = 128M
+
+; These settings can be overridden at runtime by the presence of environment
+; variables.
+date.timezone={{ default .Env.TZ "UTC" }}
+{{ if .Env.PHP_MEMORY_LIMIT }}memory_limit={{ .Env.PHP_MEMORY_LIMIT }}{{ end }}
+{{ if .Env.SENDMAIL_PATH }}sendmail_path={{ .Env.SENDMAIL_PATH }}{{ end }}
+
+; XDebug can be conditionally triggered.
+{{ if .Env.XDEBUG_ENABLE }}
+xdebug.remote_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
+xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
+xdebug.remote_enable={{ default .Env.XDEBUG_REMOTE_ENABLE "On" }}
+xdebug.remote_autostart={{ default .Env.XDEBUG_REMOTE_AUTOSTART "On" }}
+{{ end }}

--- a/8.1/test.yml
+++ b/8.1/test.yml
@@ -1,0 +1,31 @@
+schemaVersion: "2.0.0"
+commandTests:
+  - name: "php should be configurable by environment variables"
+    setup: [["docker-php-entrypoint"]]
+    envVars:
+      - {key: PHP_MEMORY_LIMIT, value: 512M }
+      - {key: SENDMAIL_PATH, value: /bin/true }
+      - {key: TZ, value: America/New_York }
+    command: "php"
+    args: ["-i"]
+    expectedOutput:
+      - memory_limit => 512M => 512M
+      - sendmail_path => /bin/true => /bin/true
+      - date.timezone => America/New_York => America/New_York
+  - name: "php should use have default values"
+    setup: [["docker-php-entrypoint"]]
+    command: "php"
+    args: ["-i"]
+    expectedOutput:
+      - memory_limit => 128M => 128M
+      - sendmail_path =>  -t -i  =>  -t -i
+      - date.timezone => UTC => UTC
+  - name: "Composer should work"
+    command: composer
+    args: ["diagnose"]
+  - name: "Drush should be launchable"
+    command: drush
+    args: ["--drush-launcher-version"]
+    expectedOutput:
+      - "Drush Launcher Version: 0.6.0"
+

--- a/8.1/test.yml
+++ b/8.1/test.yml
@@ -18,7 +18,7 @@ commandTests:
     args: ["-i"]
     expectedOutput:
       - memory_limit => 128M => 128M
-      - sendmail_path =>  -t -i  =>  -t -i
+      - sendmail_path => (?:\/usr\/sbin\/sendmail)? -t -i\s*=> (?:\/usr\/sbin\/sendmail)? -t -i
       - date.timezone => UTC => UTC
   - name: "Composer should work"
     command: composer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,28 +5,40 @@ services:
     build: ./7.0
   "7.0-dev":
     image: lastcallmedia/php:7.0-dev
-    build: ./7.0-dev 
+    build: ./7.0-dev
   "7.1":
     image: lastcallmedia/php:7.1
     build: ./7.1
   "7.1-dev":
     image: lastcallmedia/php:7.1-dev
-    build: ./7.1-dev 
+    build: ./7.1-dev
   "7.2":
     image: lastcallmedia/php:7.2
     build: ./7.2
   "7.2-dev":
     image: lastcallmedia/php:7.2-dev
-    build: ./7.2-dev 
+    build: ./7.2-dev
   "7.3":
     image: lastcallmedia/php:7.3
     build: ./7.3
   "7.3-dev":
     image: lastcallmedia/php:7.3-dev
-    build: ./7.3-dev 
+    build: ./7.3-dev
   "7.4":
     image: lastcallmedia/php:7.4
     build: ./7.4
   "7.4-dev":
     image: lastcallmedia/php:7.4-dev
-    build: ./7.4-dev 
+    build: ./7.4-dev
+  "8.0":
+    image: lastcallmedia/php:8.0
+    build: ./8.0
+  "8.0-dev":
+    image: lastcallmedia/php:8.0-dev
+    build: ./8.0-dev
+  "8.1":
+    image: lastcallmedia/php:8.1
+    build: ./8.1
+  "8.1-dev":
+    image: lastcallmedia/php:8.1-dev
+    build: ./8.1-dev

--- a/regenerate.sh
+++ b/regenerate.sh
@@ -30,9 +30,9 @@ for PHP_VERSION in "${php_versions[@]}"; do
 
   # For php versions < 7.3, we need to specify xdebug version
   if version_at_least "$PHP_VERSION" "7.3"; then
-    xdebug_version_string=""
+    xdebug_3="1"
   else
-    xdebug_version_string="-2.9.0"
+    xdebug_3=""
   fi
 
   # Determine node version
@@ -79,8 +79,8 @@ for PHP_VERSION in "${php_versions[@]}"; do
   devDir="${dir}-dev"
   rm -rf $devDir
   mkdir -p $devDir
-  PHP_VERSION=$PHP_VERSION PHP_MAJOR_VERSION=$major PHP_MINOR_VERSION=$minor PHP_AT_LEAST_7_4=$php_at_least_7_4 COMPOSER_VERSION=$composer_version IS_DEV=true XDEBUG_VERSION_STRING=$xdebug_version_string NODE_MAJOR_VERSION=$node_version TERMINUS_VERSION=$terminus_version TERMINUS_SHA=$terminus_sha dockerize -template template/Dockerfile:$devDir/Dockerfile
-  PHP_VERSION=$PHP_VERSION PHP_MAJOR_VERSION=$major PHP_MINOR_VERSION=$minor PHP_AT_LEAST_7_4=$php_at_least_7_4 COMPOSER_VERSION=$composer_version IS_DEV=true XDEBUG_VERSION_STRING=$xdebug_version_string NODE_MAJOR_VERSION=$node_version TERMINUS_VERSION=$terminus_version TERMINUS_SHA=$terminus_sha dockerize -template template/test.yml:$devDir/test.yml
+  PHP_VERSION=$PHP_VERSION PHP_MAJOR_VERSION=$major PHP_MINOR_VERSION=$minor PHP_AT_LEAST_7_4=$php_at_least_7_4 COMPOSER_VERSION=$composer_version IS_DEV=true XDEBUG_3=$xdebug_3 NODE_MAJOR_VERSION=$node_version TERMINUS_VERSION=$terminus_version TERMINUS_SHA=$terminus_sha dockerize -template template/Dockerfile:$devDir/Dockerfile
+  PHP_VERSION=$PHP_VERSION PHP_MAJOR_VERSION=$major PHP_MINOR_VERSION=$minor PHP_AT_LEAST_7_4=$php_at_least_7_4 COMPOSER_VERSION=$composer_version IS_DEV=true XDEBUG_3=$xdebug_3 NODE_MAJOR_VERSION=$node_version TERMINUS_VERSION=$terminus_version TERMINUS_SHA=$terminus_sha dockerize -template template/test.yml:$devDir/test.yml
   cp -r template/scripts "$devDir/scripts"
   cp -r template/templates "$devDir/templates"
   dc+="  \"$PHP_VERSION-dev\":\n    image: lastcallmedia/php:$PHP_VERSION-dev\n    build: $devDir\n"

--- a/regenerate.sh
+++ b/regenerate.sh
@@ -12,18 +12,57 @@ set -e
 # ./regenerate.sh
 #
 #####
-php_versions=('7.0' '7.1' '7.2' '7.3' '7.4')
+php_versions=('7.0' '7.1' '7.2' '7.3' '7.4' '8.0' '8.1')
 dc="version: '2'\nservices:\n"
+
+version_at_least () {
+  a_major=$(echo "$1" | awk -F'.' '{ print $1 }')
+  a_minor=$(echo "$1" | awk -F'.' '{ print $2 }')
+  b_major=$(echo "$2" | awk -F'.' '{ print $1 }')
+  b_minor=$(echo "$2" | awk -F'.' '{ print $2 }')
+
+  [[ "$a_major" -gt "$b_major" || ("$a_major" -eq "$b_major" && "$a_minor" -ge "$b_minor") ]]
+}
 
 for PHP_VERSION in "${php_versions[@]}"; do
   major=$(echo "$PHP_VERSION" | awk -F'.' '{ print $1 }')
   minor=$(echo "$PHP_VERSION" | awk -F'.' '{ print $2 }')
 
+  # For php versions < 7.3, we need to specify xdebug version
+  if version_at_least "$PHP_VERSION" "7.3"; then
+    xdebug_version_string=""
+  else
+    xdebug_version_string="-2.9.0"
+  fi
+
+  # Determine node version
+  if version_at_least "$PHP_VERSION" "8.0"; then
+    node_version=16
+  elif version_at_least "$PHP_VERSION" "7.4"; then
+    node_version=14
+  else
+    node_version=10
+  fi
+
+  # Determine compose version
+  if version_at_least "$PHP_VERSION" "8.0"; then
+    composer_version="2.3.10"
+  elif version_at_least "$PHP_VERSION" "7.4"; then
+    composer_version="2.0.11"
+  else
+    composer_version="1.10.20"
+  fi
+
+  # Configure options changed in 7.4
+  # Negate the result, because bash returns `0` for true and `1` for false
+  ! version_at_least "$PHP_VERSION" "7.4"
+  php_at_least_7_4=$?
+
   dir="./$PHP_VERSION"
   rm -rf $dir
   mkdir -p $dir
-  PHP_VERSION=$PHP_VERSION PHP_MAJOR_VERSION=$major PHP_MINOR_VERSION=$minor dockerize -template template/Dockerfile:$dir/Dockerfile
-  PHP_VERSION=$PHP_VERSION PHP_MAJOR_VERSION=$major PHP_MINOR_VERSION=$minor dockerize -template template/test.yml:$dir/test.yml
+  PHP_VERSION=$PHP_VERSION PHP_MAJOR_VERSION=$major PHP_MINOR_VERSION=$minor PHP_AT_LEAST_7_4=$php_at_least_7_4 COMPOSER_VERSION=$composer_version dockerize -template template/Dockerfile:$dir/Dockerfile
+  PHP_VERSION=$PHP_VERSION PHP_MAJOR_VERSION=$major PHP_MINOR_VERSION=$minor PHP_AT_LEAST_7_4=$php_at_least_7_4 COMPOSER_VERSION=$composer_version dockerize -template template/test.yml:$dir/test.yml
   cp -r template/scripts "$dir/scripts"
   cp -r template/templates "$dir/templates"
   dc+="  \"$PHP_VERSION\":\n    image: lastcallmedia/php:$PHP_VERSION\n    build: $dir\n"
@@ -31,11 +70,11 @@ for PHP_VERSION in "${php_versions[@]}"; do
   devDir="${dir}-dev"
   rm -rf $devDir
   mkdir -p $devDir
-  PHP_VERSION=$PHP_VERSION PHP_MAJOR_VERSION=$major PHP_MINOR_VERSION=$minor IS_DEV=true dockerize -template template/Dockerfile:$devDir/Dockerfile
-  PHP_VERSION=$PHP_VERSION PHP_MAJOR_VERSION=$major PHP_MINOR_VERSION=$minor IS_DEV=true dockerize -template template/test.yml:$devDir/test.yml
+  PHP_VERSION=$PHP_VERSION PHP_MAJOR_VERSION=$major PHP_MINOR_VERSION=$minor PHP_AT_LEAST_7_4=$php_at_least_7_4 COMPOSER_VERSION=$composer_version IS_DEV=true XDEBUG_VERSION_STRING=$xdebug_version_string NODE_MAJOR_VERSION=$node_version dockerize -template template/Dockerfile:$devDir/Dockerfile
+  PHP_VERSION=$PHP_VERSION PHP_MAJOR_VERSION=$major PHP_MINOR_VERSION=$minor PHP_AT_LEAST_7_4=$php_at_least_7_4 COMPOSER_VERSION=$composer_version IS_DEV=true XDEBUG_VERSION_STRING=$xdebug_version_string NODE_MAJOR_VERSION=$node_version dockerize -template template/test.yml:$devDir/test.yml
   cp -r template/scripts "$devDir/scripts"
   cp -r template/templates "$devDir/templates"
-  dc+="  \"$PHP_VERSION-dev\":\n    image: lastcallmedia/php:$PHP_VERSION-dev\n    build: $devDir \n"
+  dc+="  \"$PHP_VERSION-dev\":\n    image: lastcallmedia/php:$PHP_VERSION-dev\n    build: $devDir\n"
 done
 
 printf "$dc" > docker-compose.yml

--- a/regenerate.sh
+++ b/regenerate.sh
@@ -53,6 +53,15 @@ for PHP_VERSION in "${php_versions[@]}"; do
     composer_version="1.10.20"
   fi
 
+  # Determine terminus version
+  if version_at_least "$PHP_VERSION" "8.0"; then
+    terminus_version="3.0.7"
+    terminus_sha="f8fd66afb825ba2314a3c1d9a0b0e7e3dedbe687668613bd511ff6b41c4c6516"
+  else
+    terminus_version="2.2.0"
+    terminus_sha="73fcdf6ceee23731c20bff45f668bde09230af347670a92e5ca97c2c008ae6e0"
+  fi
+
   # Configure options changed in 7.4
   # Negate the result, because bash returns `0` for true and `1` for false
   ! version_at_least "$PHP_VERSION" "7.4"
@@ -70,8 +79,8 @@ for PHP_VERSION in "${php_versions[@]}"; do
   devDir="${dir}-dev"
   rm -rf $devDir
   mkdir -p $devDir
-  PHP_VERSION=$PHP_VERSION PHP_MAJOR_VERSION=$major PHP_MINOR_VERSION=$minor PHP_AT_LEAST_7_4=$php_at_least_7_4 COMPOSER_VERSION=$composer_version IS_DEV=true XDEBUG_VERSION_STRING=$xdebug_version_string NODE_MAJOR_VERSION=$node_version dockerize -template template/Dockerfile:$devDir/Dockerfile
-  PHP_VERSION=$PHP_VERSION PHP_MAJOR_VERSION=$major PHP_MINOR_VERSION=$minor PHP_AT_LEAST_7_4=$php_at_least_7_4 COMPOSER_VERSION=$composer_version IS_DEV=true XDEBUG_VERSION_STRING=$xdebug_version_string NODE_MAJOR_VERSION=$node_version dockerize -template template/test.yml:$devDir/test.yml
+  PHP_VERSION=$PHP_VERSION PHP_MAJOR_VERSION=$major PHP_MINOR_VERSION=$minor PHP_AT_LEAST_7_4=$php_at_least_7_4 COMPOSER_VERSION=$composer_version IS_DEV=true XDEBUG_VERSION_STRING=$xdebug_version_string NODE_MAJOR_VERSION=$node_version TERMINUS_VERSION=$terminus_version TERMINUS_SHA=$terminus_sha dockerize -template template/Dockerfile:$devDir/Dockerfile
+  PHP_VERSION=$PHP_VERSION PHP_MAJOR_VERSION=$major PHP_MINOR_VERSION=$minor PHP_AT_LEAST_7_4=$php_at_least_7_4 COMPOSER_VERSION=$composer_version IS_DEV=true XDEBUG_VERSION_STRING=$xdebug_version_string NODE_MAJOR_VERSION=$node_version TERMINUS_VERSION=$terminus_version TERMINUS_SHA=$terminus_sha dockerize -template template/test.yml:$devDir/test.yml
   cp -r template/scripts "$devDir/scripts"
   cp -r template/templates "$devDir/templates"
   dc+="  \"$PHP_VERSION-dev\":\n    image: lastcallmedia/php:$PHP_VERSION-dev\n    build: $devDir\n"

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -134,8 +134,8 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
 
 # Terminus.
-ARG TERMINUS_VERSION=2.2.0
-ARG TERMINUS_SHA256="73fcdf6ceee23731c20bff45f668bde09230af347670a92e5ca97c2c008ae6e0"
+ARG TERMINUS_VERSION={{ .Env.TERMINUS_VERSION }}
+ARG TERMINUS_SHA256="{{ .Env.TERMINUS_SHA }}"
 RUN curl -fsSOL https://github.com/pantheon-systems/terminus/releases/download/$TERMINUS_VERSION/terminus.phar \
   && echo "$TERMINUS_SHA256 terminus.phar" | sha256sum -c - \
   && mv terminus.phar /usr/local/bin/terminus \

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -120,6 +120,8 @@ RUN apt-get update \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # XDebug
+# TODO: Remove xdebug next time it causes problems. It is a lot of effort
+# to maintain, and no one is actually using it.
 RUN pecl install xdebug{{ if not .Env.XDEBUG_3 }}-2.9.0{{ end }} \
   && docker-php-ext-enable xdebug \
 {{ if .Env.XDEBUG_3 }}  && echo "xdebug.mode=debug" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -113,6 +113,8 @@ RUN apt-get update \
   && echo "deb-src https://deb.nodesource.com/node_$NODE_MAJOR_VERSION.x $(lsb_release --codename | cut -f2) main" >> /etc/apt/sources.list.d/nodesource.list \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
   && apt-get update \
+  # Force apt to use the deb.nodesource repository
+  && echo "Package: nodejs\nPin: origin deb.nodesource.com\nPin-priority: 1000" > /etc/apt/preferences.d/99-nodejs \
   && apt-get install -y nodejs \
   && apt-get install -y --no-install-recommends yarn \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -118,9 +118,10 @@ RUN apt-get update \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # XDebug
-RUN pecl install xdebug{{ .Env.XDEBUG_VERSION_STRING }} \
+RUN pecl install xdebug{{ if not .Env.XDEBUG_3 }}-2.9.0{{ end }} \
   && docker-php-ext-enable xdebug \
-  && echo "xdebug.default_enable=0\nxdebug.coverage_enable=0" > $PHP_INI_DIR/conf.d/xdebug.ini
+{{ if .Env.XDEBUG_3 }}  && echo "xdebug.mode=debug" > $PHP_INI_DIR/conf.d/xdebug.ini
+{{ else }}  && echo "xdebug.default_enable=0\nxdebug.coverage_enable=0" > $PHP_INI_DIR/conf.d/xdebug.ini{{ end }}
 
 # Blackfire Probe. Note: We do not install Blackfire CLI. You will
 # need that in order to trigger Blackfire tests. The probe just instruments

--- a/template/scripts/docker-php-entrypoint
+++ b/template/scripts/docker-php-entrypoint
@@ -4,7 +4,12 @@ set -e
 # Write overrides to PHP and Apache. This is incompatible with starting the container
 # with any user other than root, but that's not advised for the PHP Apache container
 # anyway.
-dockerize \
+
+# PHP 7.3 is the first version that uses Xdebug 3; it's easier to check
+# the php version in here than the Xdebug version
+php_at_least_7_3=$(php -r 'echo version_compare(PHP_VERSION, "7.3") >= 0;')
+
+PHP_AT_LEAST_7_3=$php_at_least_7_3 dockerize \
   -template /templates/php.overrides.tmpl:$PHP_INI_DIR/conf.d/99-runtime.ini \
   -template /templates/mpm_prefork.conf.tmpl:/etc/apache2/mods-enabled/mpm_prefork.conf
 

--- a/template/templates/php.overrides.tmpl
+++ b/template/templates/php.overrides.tmpl
@@ -10,8 +10,14 @@ date.timezone={{ default .Env.TZ "UTC" }}
 
 ; XDebug can be conditionally triggered.
 {{ if .Env.XDEBUG_ENABLE }}
+{{ if .Env.PHP_AT_LEAST_7_3 }}
+xdebug.client_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
+xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
+xdebug.start_with_request={{ default .Env.XDEBUG_START_WITH_REQUEST "yes" }}
+{{ else }}
 xdebug.remote_host={{ default .Env.XDEBUG_REMOTE_HOST "host.docker.internal" }}
 xdebug.idekey={{ default .Env.XDEBUG_IDEKEY "PHPSTORM" }}
 xdebug.remote_enable={{ default .Env.XDEBUG_REMOTE_ENABLE "On" }}
 xdebug.remote_autostart={{ default .Env.XDEBUG_REMOTE_AUTOSTART "On" }}
+{{ end }}
 {{ end }}

--- a/template/test.yml
+++ b/template/test.yml
@@ -57,13 +57,22 @@ commandTests:
       - {key: XDEBUG_ENABLE, value: True }
       - {key: XDEBUG_REMOTE_HOST, value: foo.bar}
       - {key: XDEBUG_IDEKEY, value: foobar}
+{{ if .Env.XDEBUG_3 }}
+      - {key: XDEBUG_START_WITH_REQUEST, value: "yes"}
+{{ else }}
       - {key: XDEBUG_REMOTE_ENABLE, value: 1}
       - {key: XDEBUG_REMOTE_AUTOSTART, value: 1}
+{{ end }}
     expectedOutput:
+      - xdebug.idekey => foobar => foobar
+{{ if .Env.XDEBUG_3 }}
+      - xdebug.start_with_request => yes => yes
+      - xdebug.client_host => foo.bar => foo.bar
+{{ else }}
       - xdebug.remote_autostart => On => On
       - xdebug.remote_enable => On => On
       - xdebug.remote_host => foo.bar => foo.bar
-      - xdebug.idekey => foobar => foobar
+{{ end }}
   - name: "NodeJS Should be installed and in the correct version"
     command: "node"
     args: ["--version"]

--- a/template/test.yml
+++ b/template/test.yml
@@ -18,7 +18,7 @@ commandTests:
     args: ["-i"]
     expectedOutput:
       - memory_limit => 128M => 128M
-      - sendmail_path =>  -t -i  =>  -t -i
+      - sendmail_path => (?:\/usr\/sbin\/sendmail)? -t -i\s*=> (?:\/usr\/sbin\/sendmail)? -t -i
       - date.timezone => UTC => UTC
   - name: "Composer should work"
     command: composer


### PR DESCRIPTION
Needed a lot of updates:
  - php changes to sendmail path
  - xdebug version update, most xdebug config settings changed
  - debian updated nodejs, debian package was overriding nodesource package on some versions
  - terminus version needed to be updated for php 8
  - upgraded to node 16 for php 8
  - template file was getting very hard to read with checking both major & minor version updates, moved most of the complicated stuff to the regenerate.sh file